### PR TITLE
fix: trim value to blank spaces do not fail email validation regex

### DIFF
--- a/src/components/input-chips/input-chips.tsx
+++ b/src/components/input-chips/input-chips.tsx
@@ -177,7 +177,8 @@ export class InputChips {
   }
 
   private validateChip(name: string) {
-    if (this.type === 'email' && emailValidation(name)) {
+    const trimmedName = name.trim();
+    if (this.type === 'email' && emailValidation(trimmedName)) {
       return false;
     }
     return true;


### PR DESCRIPTION
bugfix/email-validation-error-with-blank-space