### PR TITLE
fix(radio-button): prevent click event triggering twice

### DIFF
--- a/src/components/radio/radio.tsx
+++ b/src/components/radio/radio.tsx
@@ -61,6 +61,7 @@ export class Radio {
   private onClick = (event: Event): void => {
     this.checked = !this.checked;
     (event.target as HTMLInputElement).checked = this.checked;
+    event.stopPropagation();
   };
 
   private refNativeInput = (input: HTMLInputElement): void => {


### PR DESCRIPTION
The click event was triggering twice because of an event bubbling

This behaviour prevented the correct use of listeners like `onclick` and `ng-click` because any fucntion binded to these events were being triggered twice. 

With the `Event.stopPropagation` on the `onClick ` function, only one of the elements trigger the event.