### PR TITLE
fix(radio-button): add onclick output event

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1800,9 +1800,9 @@ declare namespace LocalJSX {
          */
         "onBdsChange"?: (event: CustomEvent<any>) => void;
         /**
-          * Emitted when the input has changed.
+          * Emitted when the value has changed because of a click event.
          */
-        "onBdsInput"?: (event: CustomEvent<KeyboardEvent>) => void;
+        "onBdsClickChange"?: (event: CustomEvent<any>) => void;
         "refer": string;
         "value": string;
     }

--- a/src/components/radio/radio.tsx
+++ b/src/components/radio/radio.tsx
@@ -37,6 +37,11 @@ export class Radio {
    */
   @Event() bdsChange!: EventEmitter;
 
+  /**
+   * Emitted when the value has changed because of a click event.
+   */
+  @Event() bdsClickChange!: EventEmitter;
+
   @Watch('checked')
   protected checkedChanged(isChecked: boolean): void {
     this.bdsChange.emit({ checked: isChecked });
@@ -54,7 +59,7 @@ export class Radio {
 
   private onClick = (event: Event): void => {
     this.checked = !this.checked;
-    (event.target as HTMLInputElement).checked = this.checked;
+    this.bdsClickChange.emit({ checked: this.checked });
     event.stopPropagation();
   };
 

--- a/src/components/radio/readme.md
+++ b/src/components/radio/readme.md
@@ -19,10 +19,10 @@
 
 ## Events
 
-| Event       | Description                         | Type                         |
-| ----------- | ----------------------------------- | ---------------------------- |
-| `bdsChange` | Emitted when the value has changed. | `CustomEvent<any>`           |
-| `bdsInput`  | Emitted when the input has changed. | `CustomEvent<KeyboardEvent>` |
+| Event            | Description                                                  | Type               |
+| ---------------- | ------------------------------------------------------------ | ------------------ |
+| `bdsChange`      | Emitted when the value has changed.                          | `CustomEvent<any>` |
+| `bdsClickChange` | Emitted when the value has changed because of a click event. | `CustomEvent<any>` |
 
 
 ## Methods


### PR DESCRIPTION
At the moment, it is only possible to know the `checked` value if the `bdsChange` event is triggered. If more than one radio button is using that event and triggering a function that can change its `checked` values, the event will continue to be called in an infinite loop. To avoid this, the `bdsClickChange` event will only trigger on manual entries on the radio button, avoiding the `bdsChange` call loop.
Another advantage of an internal click event output is that the `checked` value can be accessed through it.