### PR TITLE
feat(select-options): add description to select-options component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -781,6 +781,10 @@ export namespace Components {
          */
         "slotAlign"?: string;
         /**
+          * If set, a text will be displayed on the right side of the option label
+         */
+        "status"?: string;
+        /**
           * If set, a title will be shown under the text
          */
         "titleText": string;
@@ -2078,6 +2082,10 @@ declare namespace LocalJSX {
           * Alignment of input-left slot. The value need to be one of the values used on flexbox align-self property.
          */
         "slotAlign"?: string;
+        /**
+          * If set, a text will be displayed on the right side of the option label
+         */
+        "status"?: string;
         /**
           * If set, a title will be shown under the text
          */

--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -29,7 +29,8 @@
     .close-button {
       color: $color-neutral-dark-rooftop;
       align-self: flex-end;
-      padding-bottom: 16px;
+      margin-bottom: 16px;
+      cursor: pointer;
     }
 
   }

--- a/src/components/select-option/readme.md
+++ b/src/components/select-option/readme.md
@@ -15,6 +15,7 @@
 | `invisible`          | `invisible`   | Add state danger on input, use for use feedback.                                                          | `boolean` | `false`     |
 | `selected`           | `selected`    | The text value of the option.                                                                             | `boolean` | `false`     |
 | `slotAlign`          | `slot-align`  | Alignment of input-left slot. The value need to be one of the values used on flexbox align-self property. | `string`  | `'center'`  |
+| `status`             | `status`      | If set, a text will be displayed on the right side of the option label                                    | `string`  | `undefined` |
 | `titleText`          | `title-text`  | If set, a title will be shown under the text                                                              | `string`  | `undefined` |
 | `value` _(required)_ | `value`       |                                                                                                           | `any`     | `undefined` |
 

--- a/src/components/select-option/select-option.scss
+++ b/src/components/select-option/select-option.scss
@@ -43,17 +43,28 @@ $select-option-left: 12px;
     align-items: center;
     justify-content: space-between;
 
-    &--bulk {
+    &__fill_space {
+      width: 100%;
+    }
+
+    &--bulk, &--status {
       color: $color-neutral-medium-cloud;
     }
 
+    &__overflow {
+      overflow: hidden;
+      padding-right: 16px;
+    }
+
     &:hover > &--value,
-    &:hover > &--bulk {
+    &:hover > &--bulk,
+    &:hover > &--status {
       color: $color-primary-main;
     }
 
     &:active > &--value,
-    &:active > &--bulk {
+    &:active > &--bulk,
+    &:active > &--status {
       color: $color-primary-main;
     }
   }

--- a/src/components/select-option/select-option.tsx
+++ b/src/components/select-option/select-option.tsx
@@ -39,10 +39,16 @@ export class SelectOption {
    *  Alignment of input-left slot. The value need to be one of the values used on flexbox align-self property.
    */
   @Prop() slotAlign? = 'center';
+
   /**
    *  If set, a title will be shown under the text
    */
   @Prop() titleText: string;
+
+  /**
+   *  If set, a text will be displayed on the right side of the option label
+   */
+  @Prop() status?: string;
 
   @Event() optionSelected: EventEmitter;
 
@@ -93,16 +99,36 @@ export class SelectOption {
         <div style={{ alignSelf: this.slotAlign }}>
           <slot name="input-left"></slot>
         </div>
-        <div class="select-option__container">
-          <bds-typo class="select-option__container--value" variant="fs-14">
+
+        <div
+          class={{
+            'select-option__container': true,
+            'select-option__container__fill_space': !!this.status,
+          }}
+        >
+          <bds-typo
+            class={{
+              'select-option__container--value': true,
+              'select-option__container__overflow': !!this.status,
+            }}
+            noWrap={!!this.status}
+            variant="fs-14"
+          >
             <bds-typo class="select-option__container--value" variant="fs-16" bold="semi-bold">
               {this.titleText}
             </bds-typo>
             <slot />
           </bds-typo>
-          <bds-typo class="select-option__container--bulk" variant="fs-10">
-            {this.bulkOption}
-          </bds-typo>
+          {this.bulkOption && (
+            <bds-typo class="select-option__container--bulk" variant="fs-10">
+              {this.bulkOption}
+            </bds-typo>
+          )}
+          {this.status && (
+            <bds-typo class="select-option__container--status" noWrap={true} variant="fs-10">
+              {this.status}
+            </bds-typo>
+          )}
         </div>
       </div>
     );

--- a/src/components/select-option/select-option.tsx
+++ b/src/components/select-option/select-option.tsx
@@ -113,6 +113,7 @@ export class SelectOption {
             }}
             noWrap={!!this.status}
             variant="fs-14"
+            id={`bds-typo-label-${this.value}`}
           >
             <bds-typo class="select-option__container--value" variant="fs-16" bold="semi-bold">
               {this.titleText}

--- a/src/components/selects/select-interface.ts
+++ b/src/components/selects/select-interface.ts
@@ -4,6 +4,10 @@ export interface Option {
   value: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   label: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bulkOption?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  status?: any;
 }
 
 export interface SelectChangeEventDetail {

--- a/src/components/selects/select/select.tsx
+++ b/src/components/selects/select/select.tsx
@@ -156,7 +156,8 @@ export class Select {
   private getText = (): string => {
     const opt = this.childOptions.find((option) => option.value == this.value);
     if (opt?.status || opt?.bulkOption) {
-      return opt.value;
+      const internalOption = this.internalOptions.find((option) => option.value == opt.value);
+      return internalOption.label;
     }
     return opt?.titleText ? opt.titleText : opt?.textContent?.trim() ?? '';
   };

--- a/src/components/selects/select/select.tsx
+++ b/src/components/selects/select/select.tsx
@@ -16,6 +16,7 @@ export class Select {
   @State() text? = '';
 
   @State() internalOptions: Option[];
+
   /**
    * The options of the select
    * Should be passed this way:
@@ -23,6 +24,7 @@ export class Select {
    * Options can also be passed as child by using bds-select-option component, but passing as a child you may have some compatibility problems with Angular.
    */
   @Prop() options?: string | Option[];
+
   /**
    * the value of the select.
    */
@@ -242,7 +244,7 @@ export class Select {
         >
           {this.internalOptions ? (
             this.internalOptions.map((option, idx) => (
-              <bds-select-option value={option.value} key={idx}>
+              <bds-select-option value={option.value} key={idx} bulkOption={option.bulkOption} status={option.status}>
                 {option.label}
               </bds-select-option>
             ))

--- a/src/components/selects/select/select.tsx
+++ b/src/components/selects/select/select.tsx
@@ -156,8 +156,13 @@ export class Select {
   private getText = (): string => {
     const opt = this.childOptions.find((option) => option.value == this.value);
     if (opt?.status || opt?.bulkOption) {
-      const internalOption = this.internalOptions.find((option) => option.value == opt.value);
-      return internalOption.label;
+      if (this.internalOptions) {
+        const internalOption = this.internalOptions.find((option) => option.value == opt.value);
+        if (internalOption) {
+          return internalOption.label;
+        }
+      }
+      return opt.querySelector(`#bds-typo-label-${this.value}`).textContent;
     }
     return opt?.titleText ? opt.titleText : opt?.textContent?.trim() ?? '';
   };

--- a/src/components/selects/select/select.tsx
+++ b/src/components/selects/select/select.tsx
@@ -155,6 +155,9 @@ export class Select {
 
   private getText = (): string => {
     const opt = this.childOptions.find((option) => option.value == this.value);
+    if (opt.status || opt.bulkOption) {
+      return opt.value;
+    }
     return opt?.titleText ? opt.titleText : opt?.textContent?.trim() ?? '';
   };
 

--- a/src/components/selects/select/select.tsx
+++ b/src/components/selects/select/select.tsx
@@ -155,7 +155,7 @@ export class Select {
 
   private getText = (): string => {
     const opt = this.childOptions.find((option) => option.value == this.value);
-    if (opt.status || opt.bulkOption) {
+    if (opt?.status || opt?.bulkOption) {
       return opt.value;
     }
     return opt?.titleText ? opt.titleText : opt?.textContent?.trim() ?? '';


### PR DESCRIPTION
Enables the use of a description in the right side of the select-options component. I've also changed the cursor of the close modal button from the default to a pointer.