### PR TITLE
fix(input): add a preventDefault in isSubmit function

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -274,6 +274,7 @@ export class Input {
 
         if (this.isSubmit) {
           this.clearTextInput();
+          event.preventDefault();
         }
         break;
       case 'Backspace' || 'Delete':


### PR DESCRIPTION
When typing a text and pressing the <Enter>, bds-input, with the property "isSubmit" set to true, clears the text but inserts a line break in the component.
I believe that the correct operation would only be to clear the text and not add anything else.