### PR TITLE
fix(tabs): redirect

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -38,7 +38,7 @@ import { PaperElevation } from "./components/paper/paper-interface";
 import { progressBarColor, progressBarSize } from "./components/progress-bar/progress-bar";
 import { sidebarPosition } from "./components/sidebar/sidebar";
 import { SwitchSize } from "./components/bds-switch/bds-switch";
-import { BdsTabData, Overflow } from "./components/tabs/tabs-interface";
+import { Overflow } from "./components/tabs/tabs-interface";
 import { ActionType, ButtonActionType, CreateToastType, PositionType, VariantType } from "./components/toast/toast-interface";
 import { TooltipPostionType } from "./components/tooltip/tooltip";
 import { Bold, FontLineHeight, FontSize, Tag } from "./components/typo/typo";
@@ -1486,7 +1486,6 @@ export namespace Components {
     }
     interface BdsTab {
         "active": boolean;
-        "getChild": () => Promise<BdsTabData>;
         /**
           * Specifies the Tab group. Used to link it to the TabPanel.
          */
@@ -3866,7 +3865,7 @@ declare namespace LocalJSX {
          */
         "group": string;
         "label": string;
-        "onBdsSelect"?: (event: BdsTabCustomEvent<any>) => void;
+        "onBdsSelectTab"?: (event: BdsTabCustomEvent<any>) => void;
     }
     interface BdsTabPanel {
         "active"?: boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1495,7 +1495,6 @@ export namespace Components {
     }
     interface BdsTabPanel {
         "active": boolean;
-        "getChild": () => Promise<BdsTabData>;
         /**
           * Specifies the TabPanel group. Used to link it to the Tab.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1485,15 +1485,20 @@ export namespace Components {
         "size"?: SwitchSize;
     }
     interface BdsTab {
+        /**
+          * Prop to control externally if a tab will be active by default
+         */
         "active": boolean;
         /**
           * Specifies the Tab group. Used to link it to the TabPanel.
          */
         "group": string;
+        /**
+          * The text to be shown at the Tab
+         */
         "label": string;
     }
     interface BdsTabPanel {
-        "active": boolean;
         /**
           * Specifies the TabPanel group. Used to link it to the Tab.
          */
@@ -3859,16 +3864,24 @@ declare namespace LocalJSX {
         "size"?: SwitchSize;
     }
     interface BdsTab {
+        /**
+          * Prop to control externally if a tab will be active by default
+         */
         "active"?: boolean;
         /**
           * Specifies the Tab group. Used to link it to the TabPanel.
          */
         "group": string;
+        /**
+          * The text to be shown at the Tab
+         */
         "label": string;
-        "onBdsSelectTab"?: (event: BdsTabCustomEvent<any>) => void;
+        /**
+          * Event to emmit when the active tab should be updated
+         */
+        "onBdsTabChange"?: (event: BdsTabCustomEvent<any>) => void;
     }
     interface BdsTabPanel {
-        "active"?: boolean;
         /**
           * Specifies the TabPanel group. Used to link it to the Tab.
          */
@@ -3894,6 +3907,7 @@ declare namespace LocalJSX {
     }
     interface BdsTabs {
         "align"?: 'left' | 'center' | 'right';
+        "onBdsTabInit"?: (event: BdsTabsCustomEvent<any>) => void;
         "onScrollButtonClick"?: (event: BdsTabsCustomEvent<Overflow>) => void;
     }
     interface BdsToast {

--- a/src/components/tabs/readme.md
+++ b/src/components/tabs/readme.md
@@ -16,6 +16,7 @@
 
 | Event               | Description | Type                    |
 | ------------------- | ----------- | ----------------------- |
+| `bdsTabInit`        |             | `CustomEvent<any>`      |
 | `scrollButtonClick` |             | `CustomEvent<Overflow>` |
 
 

--- a/src/components/tabs/tab-panel/readme.md
+++ b/src/components/tabs/tab-panel/readme.md
@@ -13,19 +13,6 @@
 | `group` _(required)_ | `group`   | Specifies the TabPanel group. Used to link it to the Tab. | `string`  | `undefined` |
 
 
-## Methods
-
-### `getChild() => Promise<BdsTabData>`
-
-
-
-#### Returns
-
-Type: `Promise<BdsTabData>`
-
-
-
-
 ## Dependencies
 
 ### Depends on

--- a/src/components/tabs/tab-panel/readme.md
+++ b/src/components/tabs/tab-panel/readme.md
@@ -7,10 +7,9 @@
 
 ## Properties
 
-| Property             | Attribute | Description                                               | Type      | Default     |
-| -------------------- | --------- | --------------------------------------------------------- | --------- | ----------- |
-| `active`             | `active`  |                                                           | `boolean` | `false`     |
-| `group` _(required)_ | `group`   | Specifies the TabPanel group. Used to link it to the Tab. | `string`  | `undefined` |
+| Property             | Attribute | Description                                               | Type     | Default     |
+| -------------------- | --------- | --------------------------------------------------------- | -------- | ----------- |
+| `group` _(required)_ | `group`   | Specifies the TabPanel group. Used to link it to the Tab. | `string` | `undefined` |
 
 
 ## Dependencies

--- a/src/components/tabs/tab-panel/tab-panel.tsx
+++ b/src/components/tabs/tab-panel/tab-panel.tsx
@@ -1,4 +1,4 @@
-import { Component, ComponentInterface, h, Host, Prop } from '@stencil/core';
+import { Component, ComponentInterface, h, Host, Listen, Prop, State } from '@stencil/core';
 
 @Component({
   tag: 'bds-tab-panel',
@@ -12,12 +12,19 @@ export class TabPanel implements ComponentInterface {
 
   @Prop() active = false;
 
+  @State() isActive = this.active;
+
+  @Listen('bdsSelectTab', { target: 'body' })
+  onSelectedTab(event: CustomEvent) {
+    this.isActive = event.detail == this.group;
+  }
+
   render(): HTMLElement {
     return (
       <Host
         class={{
           'bds-tab-panel': true,
-          ['bds-tab-panel--selected']: this.active,
+          ['bds-tab-panel--selected']: this.isActive,
         }}
       >
         <bds-typo>

--- a/src/components/tabs/tab-panel/tab-panel.tsx
+++ b/src/components/tabs/tab-panel/tab-panel.tsx
@@ -1,5 +1,4 @@
-import { Component, ComponentInterface, h, Host, Method, Prop } from '@stencil/core';
-import { BdsTabData } from '../tabs-interface';
+import { Component, ComponentInterface, h, Host, Prop } from '@stencil/core';
 
 @Component({
   tag: 'bds-tab-panel',
@@ -13,22 +12,14 @@ export class TabPanel implements ComponentInterface {
 
   @Prop() active = false;
 
-  @Method()
-  async getChild(): Promise<BdsTabData> {
-    return {
-      active: this.active,
-      group: this.group,
-    };
-  }
-
   render(): HTMLElement {
-    const classes = {
-      'bds-tab-panel': true,
-      'bds-tab-panel--selected': this.active,
-    };
-
     return (
-      <Host class={classes}>
+      <Host
+        class={{
+          'bds-tab-panel': true,
+          ['bds-tab-panel--selected']: this.active,
+        }}
+      >
         <bds-typo>
           <slot />
         </bds-typo>

--- a/src/components/tabs/tab-panel/tab-panel.tsx
+++ b/src/components/tabs/tab-panel/tab-panel.tsx
@@ -10,12 +10,14 @@ export class TabPanel implements ComponentInterface {
    */
   @Prop() group!: string;
 
-  @Prop() active = false;
+  /**
+   * State to control if a tab panel is current active
+   */
+  @State() isActive = false;
 
-  @State() isActive = this.active;
-
-  @Listen('bdsSelectTab', { target: 'body' })
-  onSelectedTab(event: CustomEvent) {
+  @Listen('bdsTabChange', { target: 'body' })
+  @Listen('bdsTabInit', { target: 'body' })
+  handleTabChange(event: CustomEvent) {
     this.isActive = event.detail == this.group;
   }
 

--- a/src/components/tabs/tab/readme.md
+++ b/src/components/tabs/tab/readme.md
@@ -7,18 +7,18 @@
 
 ## Properties
 
-| Property             | Attribute | Description                                               | Type      | Default     |
-| -------------------- | --------- | --------------------------------------------------------- | --------- | ----------- |
-| `active`             | `active`  |                                                           | `boolean` | `false`     |
-| `group` _(required)_ | `group`   | Specifies the Tab group. Used to link it to the TabPanel. | `string`  | `undefined` |
-| `label` _(required)_ | `label`   |                                                           | `string`  | `undefined` |
+| Property             | Attribute | Description                                                   | Type      | Default     |
+| -------------------- | --------- | ------------------------------------------------------------- | --------- | ----------- |
+| `active`             | `active`  | Prop to control externally if a tab will be active by default | `boolean` | `false`     |
+| `group` _(required)_ | `group`   | Specifies the Tab group. Used to link it to the TabPanel.     | `string`  | `undefined` |
+| `label` _(required)_ | `label`   | The text to be shown at the Tab                               | `string`  | `undefined` |
 
 
 ## Events
 
-| Event          | Description | Type               |
-| -------------- | ----------- | ------------------ |
-| `bdsSelectTab` |             | `CustomEvent<any>` |
+| Event          | Description                                          | Type               |
+| -------------- | ---------------------------------------------------- | ------------------ |
+| `bdsTabChange` | Event to emmit when the active tab should be updated | `CustomEvent<any>` |
 
 
 ## Dependencies

--- a/src/components/tabs/tab/readme.md
+++ b/src/components/tabs/tab/readme.md
@@ -16,22 +16,9 @@
 
 ## Events
 
-| Event       | Description | Type               |
-| ----------- | ----------- | ------------------ |
-| `bdsSelect` |             | `CustomEvent<any>` |
-
-
-## Methods
-
-### `getChild() => Promise<BdsTabData>`
-
-
-
-#### Returns
-
-Type: `Promise<BdsTabData>`
-
-
+| Event          | Description | Type               |
+| -------------- | ----------- | ------------------ |
+| `bdsSelectTab` |             | `CustomEvent<any>` |
 
 
 ## Dependencies

--- a/src/components/tabs/tab/tab.tsx
+++ b/src/components/tabs/tab/tab.tsx
@@ -1,5 +1,4 @@
-import { Component, ComponentInterface, EventEmitter, Event, h, Prop, Method, Host } from '@stencil/core';
-import { BdsTabData } from '../tabs-interface';
+import { Component, ComponentInterface, EventEmitter, Event, h, Prop, Host, Listen, State } from '@stencil/core';
 
 @Component({
   tag: 'bds-tab',
@@ -11,32 +10,33 @@ export class Tab implements ComponentInterface {
    */
   @Prop() group!: string;
 
-  @Event() bdsSelect: EventEmitter;
+  @Event() bdsSelectTab: EventEmitter;
 
   @Prop() label!: string;
 
   @Prop() active = false;
 
-  @Method()
-  async getChild(): Promise<BdsTabData> {
-    return {
-      active: this.active,
-      group: this.group,
-    };
+  @State() isActive = this.active;
+
+  @Listen('bdsSelectTab', { target: 'body' })
+  onSelectedTab(event: CustomEvent) {
+    this.isActive = event.detail == this.group;
   }
 
   async onClick() {
-    this.bdsSelect.emit(await this.getChild());
+    this.bdsSelectTab.emit(await this.group);
   }
 
   render(): HTMLElement {
-    const classes = {
-      'bds-tab': true,
-      'bds-tab--selected': this.active,
-    };
-    const bold = this.active ? 'bold' : 'regular';
+    const bold = this.isActive ? 'bold' : 'regular';
     return (
-      <Host class={classes} onClick={this.onClick.bind(this)}>
+      <Host
+        class={{
+          'bds-tab': true,
+          ['bds-tab--selected']: this.isActive,
+        }}
+        onClick={this.onClick.bind(this)}
+      >
         <div class="bds-tab__text">
           <bds-typo variant="fs-16" bold={bold}>
             {this.label}

--- a/src/components/tabs/tab/tab.tsx
+++ b/src/components/tabs/tab/tab.tsx
@@ -10,21 +10,34 @@ export class Tab implements ComponentInterface {
    */
   @Prop() group!: string;
 
-  @Event() bdsSelectTab: EventEmitter;
-
+  /**
+   * The text to be shown at the Tab
+   */
   @Prop() label!: string;
 
+  /**
+   * Prop to control externally if a tab will be active by default
+   */
   @Prop() active = false;
 
-  @State() isActive = this.active;
+  /**
+   * State to control if a tab is current active
+   */
+  @State() isActive = false;
 
-  @Listen('bdsSelectTab', { target: 'body' })
-  onSelectedTab(event: CustomEvent) {
+  /**
+   * Event to emmit when the active tab should be updated
+   */
+  @Event() bdsTabChange: EventEmitter;
+
+  @Listen('bdsTabChange', { target: 'body' })
+  @Listen('bdsTabInit', { target: 'body' })
+  handleTabChange(event: CustomEvent) {
     this.isActive = event.detail == this.group;
   }
 
   async onClick() {
-    this.bdsSelectTab.emit(await this.group);
+    this.bdsTabChange.emit(this.group);
   }
 
   render(): HTMLElement {

--- a/src/components/tabs/tab/tab.tsx
+++ b/src/components/tabs/tab/tab.tsx
@@ -35,7 +35,6 @@ export class Tab implements ComponentInterface {
       'bds-tab--selected': this.active,
     };
     const bold = this.active ? 'bold' : 'regular';
-
     return (
       <Host class={classes} onClick={this.onClick.bind(this)}>
         <div class="bds-tab__text">

--- a/src/components/tabs/tabs-interface.ts
+++ b/src/components/tabs/tabs-interface.ts
@@ -1,12 +1,3 @@
-export interface BdsTabData {
-  active: boolean;
-  group: string;
-}
-export interface TabGroup {
-  header: BdsTabData;
-  content: BdsTabData;
-}
-
 export const enum ScrollDirection {
   LEFT = 'left',
   RIGHT = 'right',

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -17,6 +17,8 @@ export class Tabs implements ComponentInterface {
 
   @Event() scrollButtonClick: EventEmitter<Overflow>;
 
+  @Event() bdsTabInit: EventEmitter;
+
   @Prop() align: 'left' | 'center' | 'right' = 'center';
 
   @Listen('scrollButtonClick')
@@ -32,7 +34,7 @@ export class Tabs implements ComponentInterface {
     this.tabsHeaderChildElement.scrollTo(options);
   }
 
-  @Listen('bdsSelectTab', { target: 'body' })
+  @Listen('bdsTabChange', { target: 'body' })
   onSelectedTab(event: CustomEvent) {
     this.handleButtonOverlay(event.detail);
   }
@@ -42,6 +44,18 @@ export class Tabs implements ComponentInterface {
     this.attachEvents();
     this.setLeftButtonVisibility(false);
     this.setRightButtonVisibility(true);
+    this.handleActiveTab();
+  }
+
+  private handleActiveTab() {
+    const tabs = Array.from(this.tabsHeaderChildElement.getElementsByTagName('bds-tab'));
+    const activeTab = tabs.find((tab) => tab.active);
+    if (activeTab) {
+      this.bdsTabInit.emit(activeTab.group);
+    } else {
+      const [firstTab] = tabs;
+      this.bdsTabInit.emit(firstTab.group);
+    }
   }
 
   private getChildElements() {


### PR DESCRIPTION
* Fixing the default bds-tabs redirect when there is no element with `active` prop.
* Allowing that any tab could be active by default, according to the active prop.
* Managing tab toggle by EventEmitters
* Code clean up