### PR TITLE
adjust padding-bottom and border-bottom height of tabs component

### DIFF
--- a/src/components/tabs/tab-group.scss
+++ b/src/components/tabs/tab-group.scss
@@ -13,7 +13,7 @@
   position: relative;
 
   &__header {
-    padding: 4px 16px;
+    padding: 4px 16px 0px 16px;
     overflow: hidden;
 
     &__itens {
@@ -45,7 +45,7 @@
         width: auto;
         display: flex;
         align-items: center;
-        border-bottom: 2px solid transparent;
+        border-bottom: 4px solid transparent;
         position: relative;
 
         &__typo{
@@ -59,7 +59,7 @@
           content: '';
           position: absolute;
           inset: -4px;
-          border: 2px solid transparent;
+          border: 4px solid transparent;
           border-radius: 4px;
         }
 


### PR DESCRIPTION
Antes
![Screenshot_158](https://github.com/user-attachments/assets/a267e363-96e9-4e82-ba6b-df754fb608e1)

Depois
![Screenshot_157](https://github.com/user-attachments/assets/19360896-635f-4be5-9016-7f6c4de17af4)

Observei outras telas que utlizam componentes antigos que também utilizam a espessura da borda de 4px, padding bottom 0px;

![Screenshot_159](https://github.com/user-attachments/assets/8df46bb9-9ce2-4b60-9889-9c7d452afc12)

![Screenshot_160](https://github.com/user-attachments/assets/1e12adc2-76fe-44e8-a674-7a0cdaa23643)


