### PR TITLE
fix: remove deprecated tilde (~) imports from SASS files

### DIFF
--- a/src/globals/_colors.scss
+++ b/src/globals/_colors.scss
@@ -1,4 +1,4 @@
-@forward '~blip-tokens/build/scss/variables.scss';
+@forward 'blip-tokens/build/scss/variables.scss';
 @forward './theme/theme-light.scss';
 @forward './theme/theme-dark.scss';
 @use './theme/theme-light.scss' as *;

--- a/src/globals/theme/color-legacy.scss
+++ b/src/globals/theme/color-legacy.scss
@@ -1,1 +1,1 @@
-@forward '~blip-tokens/build/scss/variables.scss';
+@forward 'blip-tokens/build/scss/variables.scss';

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -8,16 +8,6 @@ export const config: Config = {
     sass({
       includePaths: ['src/globals', 'node_modules'],
       injectGlobalPaths: ['src/globals/helpers.scss'],
-      importer: (url) => {
-        // Handle ~ prefix for node_modules imports
-        if (url.startsWith('~')) {
-          const modulePath = url.substring(1);
-          return {
-            file: `node_modules/${modulePath}`,
-          };
-        }
-        return null;
-      },
     }),
   ],
   outputTargets: [


### PR DESCRIPTION
- Replace ~blip-tokens imports with direct module paths in _colors.scss and color-legacy.scss
- Remove custom sass importer from stencil.config.ts that was causing build issues

Breaking change: Projects importing blip-ds SASS files may need to update their build configurations