### PR TITLE
feat: add part attribute for styling in BdsMenu component

### DIFF
--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -35,7 +35,7 @@ export class BdsMenu implements ComponentInterface {
   /**
    * bdsToggle. Event to return selected date value.
    */
-  @Event() bdsToggle?: EventEmitter;
+  @Event() bdsToggle?: EventEmitter<{ value?: boolean }>;
 
   componentWillLoad() {
     this.refElement = document.getElementById(this.menu);

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -35,7 +35,7 @@ export class BdsMenu implements ComponentInterface {
   /**
    * bdsToggle. Event to return selected date value.
    */
-  @Event() bdsToggle?: EventEmitter<{ value?: boolean }>;
+  @Event() bdsToggle?: EventEmitter;
 
   componentWillLoad() {
     this.refElement = document.getElementById(this.menu);
@@ -86,6 +86,7 @@ export class BdsMenu implements ComponentInterface {
             [`menu__open`]: this.open,
           }}
           style={menuPosition}
+          part="bds-menu__container"
         >
           <slot></slot>
         </div>

--- a/src/components/menu/test/menu.spec.ts
+++ b/src/components/menu/test/menu.spec.ts
@@ -90,6 +90,16 @@ describe('bds-menu', () => {
     expect(outzone).toBeNull();
   });
 
+  it('should apply part attribute for styling', async () => {
+    const page = await newSpecPage({
+      components: [BdsMenu],
+      html: `<bds-menu></bds-menu>`,
+    });
+
+    const element = page.root.shadowRoot.querySelector('[part="bds-menu__container"]');
+    expect(element).toBeTruthy();
+  });
+
   describe('position variants', () => {
     it('should render with right position', async () => {
       const page = await newSpecPage({
@@ -327,7 +337,7 @@ describe('bds-menu', () => {
       expect(page.root).toEqualHtml(`
         <bds-menu>
           <mock:shadow-root>
-            <div class="menu menu__right" style="top: 0px; left: 0px;">
+            <div class="menu menu__right" part="bds-menu__container" style="top: 0px; left: 0px;">
               <slot></slot>
             </div>
           </mock:shadow-root>


### PR DESCRIPTION
This pull request makes improvements to the `bds-menu` component, focusing on enhancing its styling capabilities and updating related tests. The most important changes are grouped below:

**Component Enhancements:**

* Added the `part="bds-menu__container"` attribute to the menu container `<div>` in `menu.tsx` to enable external styling via the Shadow DOM part mechanism.

**Testing Updates:**

* Added a new test in `menu.spec.ts` to verify that the `part` attribute is correctly applied to the menu container, ensuring that the component supports external styling as intended.
* Updated an existing snapshot test in `menu.spec.ts` to reflect the addition of the `part` attribute on the menu container `<div>`.
