### PR TITLE
feat(tokens): migrate DS components to semantic color aliases

### DIFF
--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -10,7 +10,7 @@
   padding: 24px;
   padding-right: 56px;
   position: relative;
-  color: $color-content-default;
+  color: $color-semantic-content-primary;
   cursor: pointer;
 
   &::before {
@@ -33,7 +33,7 @@
 
   &:hover {
     &::before {
-      background-color: $color-content-default;
+      background-color: $color-semantic-content-primary;
       opacity: 0.08;
     }
   }
@@ -98,12 +98,12 @@
   }
 
   &_divisor {
-    border-bottom: 1px solid $color-border-1;
+    border-bottom: 1px solid $color-semantic-border-actions;
   }
 
   & .container {
     padding: 8px 24px 48px;
     position: relative;
-    color: $color-content-default;
+    color: $color-semantic-content-primary;
   }
 }

--- a/src/components/alert/alert-header/alert-header.scss
+++ b/src/components/alert/alert-header/alert-header.scss
@@ -19,33 +19,33 @@
     background: $color-system;
 
     bds-typo {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
 
     .color-icon {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
   }
 
   &--error {
     background: $color-error;
     bds-typo {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
     
     .color-icon {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
   }
 
   &--warning {
     background: $color-warning;
     bds-typo {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
     
     .color-icon {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
   }
 

--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -129,12 +129,12 @@ $select-options-max-height: 250px;
       }
       @include input-theme(
         'primary',
-        $color-primary,
+        $color-semantic-action-primary-default,
         $color-surface-1,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-primary,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-action-primary-default,
         $color-info
       );
     }
@@ -157,10 +157,10 @@ $select-options-max-height: 250px;
       }
       @include input-theme(
         'danger',
-        $color-negative,
+        $color-semantic-feedback-negative,
         $color-error,
         $color-delete,
-        $color-content-default,
+        $color-semantic-content-primary,
         $color-delete,
         $color-delete,
         $color-error
@@ -186,10 +186,10 @@ $select-options-max-height: 250px;
         'success',
         $color-positive,
         $color-success,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-content-default,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-content-primary,
         $color-success
       );
     }
@@ -299,10 +299,10 @@ $select-options-max-height: 250px;
 
     &--danger {
       .bds-icon {
-        color: $color-negative;
+        color: $color-semantic-feedback-negative;
       }
       .input__message__text {
-        color: $color-negative;
+        color: $color-semantic-feedback-negative;
       }
     }
     &--success {
@@ -312,7 +312,7 @@ $select-options-max-height: 250px;
         }
       }
       .input__message__text {
-        color: $color-content-default;
+        color: $color-semantic-content-primary;
       }
     }
   }

--- a/src/components/banner/banner.scss
+++ b/src/components/banner/banner.scss
@@ -18,7 +18,7 @@
       width: 100%;
       padding: 8px 16px;
       min-height: 40px;
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
 
       &--context--inside {
         border-radius: 8px;
@@ -74,7 +74,7 @@
         justify-content: space-between;
         margin-left: 8px;
         width: 100%;
-        color: $color-content-default;
+        color: $color-semantic-content-primary;
       }
     }
 

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -205,11 +205,11 @@ $button-border-radius: 8px;
     &--primary.button__variant--solid,
     &--primary.button__variant--primary {
       @include button-variant(
-        $color-surface-primary,
+        $color-semantic-action-primary-default,
         transparent,
         $color-content-bright,
-        $color-surface-primary,
-        $color-surface-primary,
+        $color-semantic-action-primary-default,
+        $color-semantic-action-primary-default,
         true
       );
     }
@@ -218,26 +218,32 @@ $button-border-radius: 8px;
     &--primary.button__variant--tertiary {
       @include button-variant(
         transparent,
-        $color-primary,
-        $color-primary,
-        $color-surface-primary,
-        $color-surface-primary
+        $color-semantic-action-primary-default,
+        $color-semantic-action-primary-default,
+        $color-semantic-action-primary-default,
+        $color-semantic-action-primary-default
       );
     }
 
     &--primary.button__variant--text,
     &--primary.button__variant--secondary {
-      @include button-variant(transparent, transparent, $color-primary, $color-primary, $color-primary);
+      @include button-variant(
+        transparent,
+        transparent,
+        $color-semantic-action-primary-default,
+        $color-semantic-action-primary-default,
+        $color-semantic-action-primary-default
+      );
     }
 
     &--content.button__variant--solid,
     &--content.button__variant--primary {
       @include button-variant(
-        $color-content-default,
+        $color-semantic-content-primary,
         transparent,
         $color-surface-0,
-        $color-content-default,
-        $color-content-default,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
         true
       );
     }
@@ -246,10 +252,10 @@ $button-border-radius: 8px;
     &--content.button__variant--tertiary {
       @include button-variant(
         transparent,
-        $color-content-default,
-        $color-content-default,
-        $color-content-default,
-        $color-content-default
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary
       );
     }
 
@@ -258,9 +264,9 @@ $button-border-radius: 8px;
       @include button-variant(
         transparent,
         transparent,
-        $color-content-default,
-        $color-content-default,
-        $color-content-default
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary
       );
     }
 
@@ -282,8 +288,8 @@ $button-border-radius: 8px;
     &--negative.button__variant--delete {
       @include button-variant(
         transparent,
-        $color-negative,
-        $color-negative,
+        $color-semantic-feedback-negative,
+        $color-semantic-feedback-negative,
         $color-surface-negative,
         $color-surface-negative
       );
@@ -292,7 +298,13 @@ $button-border-radius: 8px;
     &--negative.button__variant--text,
     &--negative.button__variant--secondary,
     &--negative.button__variant--delete {
-      @include button-variant(transparent, transparent, $color-negative, $color-negative, $color-surface-negative);
+      @include button-variant(
+        transparent,
+        transparent,
+        $color-semantic-feedback-negative,
+        $color-semantic-feedback-negative,
+        $color-surface-negative
+      );
     }
 
     &--positive.button__variant--solid,

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -46,8 +46,8 @@ $checkbox-spacing-text: 8px;
 
   &--selected {
     .checkbox__icon {
-      background-color: $color-surface-primary;
-      border-color: $color-surface-primary;
+      background-color: $color-semantic-action-primary-default;
+      border-color: $color-semantic-action-primary-default;
 
       &__svg {
         color: $color-content-bright;
@@ -65,8 +65,8 @@ $checkbox-spacing-text: 8px;
     }
 
     .checkbox__icon {
-      color: $color-content-default;
-      border-color: $color-content-default;
+      color: $color-semantic-content-primary;
+      border-color: $color-semantic-content-primary;
       background-color: $color-surface-3;
       opacity: 50%;
     }
@@ -83,8 +83,8 @@ $checkbox-spacing-text: 8px;
 
   &--indeterminate {
     .checkbox__icon {
-      background-color: $color-surface-primary;
-      border-color: $color-surface-primary;
+      background-color: $color-semantic-action-primary-default;
+      border-color: $color-semantic-action-primary-default;
 
       &__svg {
         color: $color-content-bright;
@@ -102,8 +102,8 @@ $checkbox-spacing-text: 8px;
     }
 
     .checkbox__icon {
-      color: $color-content-default;
-      border-color: $color-content-default;
+      color: $color-semantic-content-primary;
+      border-color: $color-semantic-content-primary;
       background-color: $color-surface-3;
       opacity: 50%;
     }
@@ -120,7 +120,7 @@ $checkbox-spacing-text: 8px;
     .checkbox__icon {
       opacity: 50%;
       background-color: $color-surface-1;
-      border: 1px solid $color-brand;
+      border: 1px solid $color-semantic-action-primary-default;
     }
 
     .checkbox__icon__svg {
@@ -145,7 +145,7 @@ $checkbox-spacing-text: 8px;
     min-width: 18px;
     border-radius: $checkbox-icon-radius;
     color: $color-surface-1;
-    border: 1px solid $color-content-default;
+    border: 1px solid $color-semantic-content-primary;
     box-sizing: border-box;
     border-radius: 4px;
     @include animation();
@@ -153,6 +153,6 @@ $checkbox-spacing-text: 8px;
 
   &__text {
     margin-left: $checkbox-spacing-text;
-    color: $color-content-default;
+    color: $color-semantic-content-primary;
   }
 }

--- a/src/components/chip-clickable/chip-clickable.scss
+++ b/src/components/chip-clickable/chip-clickable.scss
@@ -161,8 +161,8 @@
       color: $color-content-din;
     }
     &--outline {
-      border: 1px solid $color-border-1;
-      color: $color-content-default;
+      border: 1px solid $color-semantic-border-actions;
+      color: $color-semantic-content-primary;
     }
     &:focus-visible {
       outline: none;

--- a/src/components/input-chips/input-chips.scss
+++ b/src/components/input-chips/input-chips.scss
@@ -151,12 +151,12 @@ $input_fixed: 140px;
       }
       @include input-theme(
         'primary',
-        $color-primary,
+        $color-semantic-action-primary-default,
         $color-surface-1,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-primary,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-action-primary-default,
         $color-info
       );
     }
@@ -179,12 +179,12 @@ $input_fixed: 140px;
       }
       @include input-theme(
         'danger',
-        $color-negative,
+        $color-semantic-feedback-negative,
         $color-error,
-        $color-delete,
-        $color-content-default,
-        $color-delete,
-        $color-delete,
+        $color-semantic-feedback-negative,
+        $color-semantic-content-primary,
+        $color-semantic-feedback-negative,
+        $color-semantic-feedback-negative,
         $color-error
       );
     }
@@ -208,10 +208,10 @@ $input_fixed: 140px;
         'success',
         $color-positive,
         $color-success,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-content-default,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-content-primary,
         $color-success
       );
     }
@@ -324,10 +324,10 @@ $input_fixed: 140px;
 
     &--danger {
       .bds-icon {
-        color: $color-negative;
+        color: $color-semantic-feedback-negative;
       }
       .input__message__text {
-        color: $color-negative;
+        color: $color-semantic-feedback-negative;
       }
     }
     &--success {
@@ -337,7 +337,7 @@ $input_fixed: 140px;
         }
       }
       .input__message__text {
-        color: $color-content-default;
+        color: $color-semantic-content-primary;
       }
     }
   }

--- a/src/components/input-editable/input-editable.scss
+++ b/src/components/input-editable/input-editable.scss
@@ -130,7 +130,7 @@ $input_fixed: 140px;
           left: 0;
           width: 100%;
           height: 100%;
-          background-color: $color-primary;
+          background-color: $color-semantic-action-primary-default;
           z-index: 0;
           opacity: 50%;
           border-radius: 8px;
@@ -138,12 +138,12 @@ $input_fixed: 140px;
       }
       @include input-theme(
         'primary',
-        $color-primary,
+        $color-semantic-action-primary-default,
         $color-surface-1,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-primary,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-action-primary-default,
         $color-info
       );
     }
@@ -158,7 +158,7 @@ $input_fixed: 140px;
           left: 0;
           width: 100%;
           height: 100%;
-          background-color: $color-delete;
+          background-color: $color-semantic-feedback-negative;
           z-index: 0;
           opacity: 50%;
           border-radius: 8px;
@@ -166,12 +166,12 @@ $input_fixed: 140px;
       }
       @include input-theme(
         'danger',
-        $color-delete,
+        $color-semantic-feedback-negative,
         $color-error,
-        $color-delete,
-        $color-content-default,
-        $color-delete,
-        $color-delete,
+        $color-semantic-feedback-negative,
+        $color-semantic-content-primary,
+        $color-semantic-feedback-negative,
+        $color-semantic-feedback-negative,
         $color-error
       );
     }
@@ -193,12 +193,12 @@ $input_fixed: 140px;
       }
       @include input-theme(
         'success',
-        $color-content-default,
+        $color-semantic-content-primary,
         $color-success,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-content-default,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-content-primary,
         $color-success
       );
     }
@@ -213,7 +213,7 @@ $input_fixed: 140px;
           left: 0;
           width: 100%;
           height: 100%;
-          background-color: $color-primary;
+          background-color: $color-semantic-action-primary-default;
           z-index: 0;
           opacity: 50%;
           border-radius: 8px;
@@ -306,10 +306,10 @@ $input_fixed: 140px;
 
     &--danger {
       .bds-icon {
-        color: $color-delete;
+        color: $color-semantic-feedback-negative;
       }
       .input__message__text {
-        color: $color-delete;
+        color: $color-semantic-feedback-negative;
       }
     }
   }
@@ -341,11 +341,11 @@ $input_fixed: 140px;
     }
     &:hover {
       .input__editable--static__typo {
-        border: 1px solid $color-primary;
+        border: 1px solid $color-semantic-action-primary-default;
       }
 
       .input__editable--static__icon {
-        color: $color-primary;
+        color: $color-semantic-action-primary-default;
       }
     }
 
@@ -358,7 +358,7 @@ $input_fixed: 140px;
       white-space: nowrap;
       overflow: hidden;
       max-width: 80%;
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
 
     &__icon {
@@ -422,18 +422,18 @@ $input_fixed: 140px;
       margin: auto 0;
 
       &--error {
-        color: $color-delete;
+        color: $color-semantic-feedback-negative;
 
         &:hover {
-          color: $color-delete;
+          color: $color-semantic-feedback-negative;
         }
       }
 
       &--checkball {
-        color: $color-primary;
+        color: $color-semantic-action-primary-default;
 
         &:hover {
-          color: $color-primary;
+          color: $color-semantic-action-primary-default;
         }
 
         &--error {

--- a/src/components/input-password/input-password.scss
+++ b/src/components/input-password/input-password.scss
@@ -147,12 +147,12 @@ $input_fixed: 140px;
       }
       @include input-theme(
         'primary',
-        $color-primary,
+        $color-semantic-action-primary-default,
         $color-surface-1,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-primary,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-action-primary-default,
         $color-info
       );
     }
@@ -175,10 +175,10 @@ $input_fixed: 140px;
       }
       @include input-theme(
         'danger',
-        $color-negative,
+        $color-semantic-feedback-negative,
         $color-error,
         $color-delete,
-        $color-content-default,
+        $color-semantic-content-primary,
         $color-delete,
         $color-delete,
         $color-error
@@ -204,10 +204,10 @@ $input_fixed: 140px;
         'success',
         $color-positive,
         $color-success,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-content-default,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-content-primary,
         $color-success
       );
     }
@@ -314,10 +314,10 @@ $input_fixed: 140px;
 
     &--danger {
       .bds-icon {
-        color: $color-negative;
+        color: $color-semantic-feedback-negative;
       }
       .input__message__text {
-        color: $color-negative;
+        color: $color-semantic-feedback-negative;
       }
     }
     &--success {
@@ -327,7 +327,7 @@ $input_fixed: 140px;
         }
       }
       .input__message__text {
-        color: $color-content-default;
+        color: $color-semantic-content-primary;
       }
     }
   }

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -148,12 +148,12 @@ $input-width: 100%;
       }
       @include input-theme(
         'primary',
-        $color-primary,
+        $color-semantic-action-primary-default,
         $color-surface-1,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-primary,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-action-primary-default,
         $color-info
       );
     }
@@ -176,10 +176,10 @@ $input-width: 100%;
       }
       @include input-theme(
         'danger',
-        $color-negative,
+        $color-semantic-feedback-negative,
         $color-error,
         $color-delete,
-        $color-content-default,
+        $color-semantic-content-primary,
         $color-delete,
         $color-delete,
         $color-error
@@ -205,10 +205,10 @@ $input-width: 100%;
         'success',
         $color-positive,
         $color-success,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-content-default,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-content-primary,
         $color-success
       );
     }

--- a/src/components/menu/menu-exibition/menu-exibition.scss
+++ b/src/components/menu/menu-exibition/menu-exibition.scss
@@ -19,7 +19,7 @@
     flex-direction: column;
 
     & .title-item {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
 
     & .subtitle-item {
@@ -27,7 +27,7 @@
     }
 
     & .description-item {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
   }
 }

--- a/src/components/radio/radio.scss
+++ b/src/components/radio/radio.scss
@@ -30,7 +30,7 @@ $radio-circle-pointer-height: 10px;
     width: $radio-circle-width;
     height: $radio-circle-height;
     flex-shrink: 0;
-    border: 2px solid $color-content-default;
+    border: 2px solid $color-semantic-content-primary;
     padding: 4px;
     border-radius: 100%;
     box-sizing: border-box;
@@ -82,23 +82,23 @@ $radio-circle-pointer-height: 10px;
   &__text {
     @include no-select();
     padding-left: $radio-spacing-text;
-    color: $color-content-default;
+    color: $color-semantic-content-primary;
   }
 
   /** State Checked */
   &__input[type='radio']:checked ~ &__circle {
     background: transparent;
-    border-color: $color-content-default;
+    border-color: $color-semantic-content-primary;
 
     .radio__circle__pointer {
-      background-color: $color-primary;
+      background-color: $color-semantic-action-primary-default;
     }
 
     &:hover {
-      border-color: $color-content-default;
+      border-color: $color-semantic-content-primary;
 
       .radio__circle__pointer {
-        background-color: $color-primary;
+        background-color: $color-semantic-action-primary-default;
       }
     }
   }
@@ -125,7 +125,7 @@ $radio-circle-pointer-height: 10px;
     background-color: $color-surface-3;
 
     .radio__circle__pointer {
-      background-color: $color-content-default;
+      background-color: $color-semantic-content-primary;
     }
   }
   &__input[type='radio']:disabled:checked:hover ~ &__circle {
@@ -133,7 +133,7 @@ $radio-circle-pointer-height: 10px;
     background-color: $color-surface-3;
 
     .radio__circle__pointer {
-      background-color: $color-content-default;
+      background-color: $color-semantic-content-primary;
     }
   }
 

--- a/src/components/select-option/select-option.scss
+++ b/src/components/select-option/select-option.scss
@@ -28,7 +28,7 @@ $select-option-left: 12px;
 
   &--selected {
     .select-option__container--value {
-      color: $color-primary;
+      color: $color-semantic-action-primary-default;
     }
   }
 
@@ -49,7 +49,7 @@ $select-option-left: 12px;
   }
 
   &__container {
-    color: $color-content-default;
+    color: $color-semantic-content-primary;
     display: flex;
     flex-direction: column;
 
@@ -89,13 +89,13 @@ $select-option-left: 12px;
     &:hover > &--value,
     &:hover > &--bulk,
     &:hover > &--status {
-      color: $color-primary;
+      color: $color-semantic-action-primary-default;
     }
 
     &:active > &--value,
     &:active > &--bulk,
     &:active > &--status {
-      color: $color-primary;
+      color: $color-semantic-action-primary-default;
     }
   }
 
@@ -105,7 +105,7 @@ $select-option-left: 12px;
 
   &:focus {
     background-color: $color-surface-1;
-    color: $color-primary-main;
+    color: $color-semantic-action-primary-default;
   }
 
   &--selected {

--- a/src/components/selects/select.scss
+++ b/src/components/selects/select.scss
@@ -149,12 +149,12 @@ $select-options-max-height: 200px;
       }
       @include input-theme(
         'primary',
-        $color-primary,
+        $color-semantic-action-primary-default,
         $color-surface-1,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-primary,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-action-primary-default,
         $color-info
       );
     }
@@ -177,10 +177,10 @@ $select-options-max-height: 200px;
       }
       @include input-theme(
         'danger',
-        $color-negative,
+        $color-semantic-feedback-negative,
         $color-error,
         $color-delete,
-        $color-content-default,
+        $color-semantic-content-primary,
         $color-delete,
         $color-delete,
         $color-error
@@ -206,10 +206,10 @@ $select-options-max-height: 200px;
         'success',
         $color-positive,
         $color-success,
-        $color-content-default,
-        $color-content-default,
-        $color-border-1,
-        $color-content-default,
+        $color-semantic-content-primary,
+        $color-semantic-content-primary,
+        $color-semantic-border-actions,
+        $color-semantic-content-primary,
         $color-success
       );
     }
@@ -313,10 +313,10 @@ $select-options-max-height: 200px;
 
     &--danger {
       .bds-icon {
-        color: $color-negative;
+        color: $color-semantic-feedback-negative;
       }
       .input__message__text {
-        color: $color-negative;
+        color: $color-semantic-feedback-negative;
       }
     }
     &--success {
@@ -326,7 +326,7 @@ $select-options-max-height: 200px;
         }
       }
       .input__message__text {
-        color: $color-content-default;
+        color: $color-semantic-content-primary;
       }
     }
   }

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -85,7 +85,7 @@
         width: 100%;
         align-items: center;
         position: relative;
-        color: $color-content-default;
+        color: $color-semantic-content-primary;
 
         ::slotted(*) {
           width: 100%;
@@ -105,7 +105,7 @@
           all 0.3s;
         z-index: 1;
         cursor: pointer;
-        color: $color-content-default;
+        color: $color-semantic-content-primary;
       }
     }
 

--- a/src/components/skeleton/skeleton.scss
+++ b/src/components/skeleton/skeleton.scss
@@ -1,7 +1,7 @@
 .skeleton {
   min-width: 8px;
   min-height: 8px;
-  background-color: $color-content-default;
+  background-color: $color-semantic-content-primary;
   opacity: 0.16;
   overflow: hidden;
 

--- a/src/components/tabs/tab (depreciated)/tab/tab.scss
+++ b/src/components/tabs/tab (depreciated)/tab/tab.scss
@@ -19,7 +19,7 @@
   }
 
   &:hover {
-    color: $color-content-default;
+    color: $color-semantic-content-primary;
   }
 
   &--selected {
@@ -36,11 +36,11 @@
   @keyframes selectFade {
     from{
        border-bottom: 2px solid transparent;
-       color: $color-content-default;
+       color: $color-semantic-content-primary;
     }
     to{
-       border-bottom: 2px solid $color-brand;
-      color: $color-content-default;
+       border-bottom: 2px solid $color-semantic-action-primary-default;
+      color: $color-semantic-content-primary;
     }
   }
 }

--- a/src/components/tabs/tab-group.scss
+++ b/src/components/tabs/tab-group.scss
@@ -54,7 +54,7 @@
             color: $color-content-ghost;
           }
           &__error {
-            color: $color-surface-negative;
+            color: $color-semantic-feedback-negative;
           }
         }
 
@@ -75,8 +75,8 @@
         }
 
         &__open {
-          color: $color-content-default;
-          border-color: $color-primary;
+          color: $color-semantic-content-primary;
+          border-color: $color-semantic-action-primary-default;
         }
         &__disable {
           cursor: no-drop;

--- a/src/components/theme-provider/theme-provider.scss
+++ b/src/components/theme-provider/theme-provider.scss
@@ -53,6 +53,13 @@
   --color-pressed: #{$color-light-pressed};
   --color-shadow-0: rgba(0, 0, 0, 0.04);
   --color-shadow-1: rgba(0, 0, 0, 0.16);
+
+  // Semantic aliases for gradual migration from legacy token names.
+  --contents-content-primary: var(--color-content-default);
+  --actions-action-primary-default: var(--color-primary);
+  --feedback-negative: var(--color-negative);
+  --borders-border-actions: var(--color-border-2);
+  --surfaces-surface-papers: var(--color-surface-0);
 }
 
 :host(.theme--dark) {
@@ -107,6 +114,13 @@
   --color-pressed: #{$color-dark-pressed};
   --color-shadow-0: #{$color-shadow-0};
   --color-shadow-1: #{$color-shadow-1};
+
+  // Semantic aliases for gradual migration from legacy token names.
+  --contents-content-primary: var(--color-content-default);
+  --actions-action-primary-default: var(--color-primary);
+  --feedback-negative: var(--color-negative);
+  --borders-border-actions: var(--color-border-2);
+  --surfaces-surface-papers: var(--color-surface-0);
 }
 
 :host(.theme--high-contrast) {
@@ -146,4 +160,11 @@
   --color-shadow-1: rgba(0, 0, 0, 0.16);
   --color-positive: #10603b;
   --color-negative: #e60f0f;
+
+  // Semantic aliases for gradual migration from legacy token names.
+  --contents-content-primary: var(--color-content-default);
+  --actions-action-primary-default: var(--color-primary);
+  --feedback-negative: var(--color-negative);
+  --borders-border-actions: var(--color-border-1);
+  --surfaces-surface-papers: var(--color-surface-1);
 }

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -32,7 +32,7 @@
   box-sizing: border-box;
   border-radius: 8px;
   box-shadow: $shadow-3;
-  color: $color-content-default;
+  color: $color-semantic-content-primary;
   opacity: 0;
   margin-top: 16px;
   overflow: hidden;

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -12,7 +12,7 @@ $tooltip-border-width: 6px;
     left: 50%;
     border-radius: 8px;
     padding: 8px;
-    background: $color-content-default;
+    background: $color-semantic-content-primary;
     z-index: $zindex-modal;
     white-space: normal;
     width: max-content;
@@ -45,7 +45,7 @@ $tooltip-border-width: 6px;
       bottom: calc(100% + 10px);
       &::before {
         top: 100%;
-        border-top-color: $color-content-default;
+        border-top-color: $color-semantic-content-primary;
       }
     }
 
@@ -85,7 +85,7 @@ $tooltip-border-width: 6px;
         left: -5px;
         top: 50%;
         transform: translateX(0) translateY(-50%);
-        border-right-color: $color-content-default;
+        border-right-color: $color-semantic-content-primary;
       }
     }
 
@@ -110,7 +110,7 @@ $tooltip-border-width: 6px;
       top: calc(100% + 10px);
       &::before {
         bottom: 100%;
-        border-bottom-color: $color-content-default;
+        border-bottom-color: $color-semantic-content-primary;
       }
     }
 
@@ -142,7 +142,7 @@ $tooltip-border-width: 6px;
         right: -11px;
         top: 50%;
         transform: translateX(0) translateY(-50%);
-        border-left-color: $color-content-default;
+        border-left-color: $color-semantic-content-primary;
       }
     }
 

--- a/src/components/typo/typo.scss
+++ b/src/components/typo/typo.scss
@@ -1,7 +1,7 @@
 @import 'fonts';
 
 :host {
-  color: $color-content-default;
+  color: $color-semantic-content-primary;
 }
 
 .typo {

--- a/src/components/upload/bds-upload.scss
+++ b/src/components/upload/bds-upload.scss
@@ -10,10 +10,10 @@
     flex-wrap: nowrap;
     align-items: center;
     gap: 8px;
-    color: $color-content-default;
+    color: $color-semantic-content-primary;
 
     &_text {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
       display: flex;
       flex-direction: column;
     }
@@ -24,7 +24,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  border: 1px solid $color-border-1;
+  border: 1px solid $color-semantic-border-actions;
   border-radius: 8px;
   cursor: pointer;
   font-weight: normal;
@@ -65,7 +65,7 @@
     text-align: center;
     z-index: 2;
     .text {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
       width: 100%;
       flex-wrap: wrap;
     }
@@ -74,28 +74,28 @@
     background-color: $color-surface-2;
 
     .text {
-      color: $color-primary;
+      color: $color-semantic-action-primary-default;
     }
   }
 }
 
 .upload__edit--label:hover {
-  border: 2px solid $color-primary;
+  border: 2px solid $color-semantic-action-primary-default;
   box-sizing: border-box;
   padding: 22px 16px;
   cursor: pointer;
-  text-decoration: underline $color-primary;
+  text-decoration: underline $color-semantic-action-primary-default;
   color: $color-brand;
 
   .text {
-    color: $color-primary;
+    color: $color-semantic-action-primary-default;
   }
 }
 
 .upload__edit--hover {
   background-size: cover;
   border: 1px dashed $color-surface-4;
-  color: $color-primary;
+  color: $color-semantic-action-primary-default;
   font-weight: bold;
   border-radius: 8px;
 }
@@ -105,8 +105,8 @@
 }
 
 .list-preview {
-  border-top: 1px solid $color-border-1;
-  border-bottom: 1px solid $color-border-1;
+  border-top: 1px solid $color-semantic-border-actions;
+  border-bottom: 1px solid $color-semantic-border-actions;
   max-height: 200px;
   overflow-y: auto;
 }
@@ -136,10 +136,10 @@
       white-space: nowrap;
       overflow: hidden;
       width: 100%;
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
     &-icon {
-      color: $color-content-default;
+      color: $color-semantic-content-primary;
     }
     &-icon:hover {
       cursor: pointer;

--- a/src/globals/_colors.scss
+++ b/src/globals/_colors.scss
@@ -31,18 +31,18 @@ $color-delete: var(--color-delete, $color-light-delete);
 $color-shadow-0: var(--color-shadow-0, rgba(0, 0, 0, 0.04));
 $color-shadow-1: var(--color-shadow-1, rgba(0, 0, 0, 0.16));
 
+//Actions
+$color-hover: var(--color-hover, rgba(0, 0, 0, 0.08));
+$color-pressed: var(--color-pressed, rgba(0, 0, 0, 0.16));
+$color-positive: var(--color-positive, #10603b);
+$color-negative: var(--color-negative, #e60f0f);
+
 // Semantic token compatibility layer (Figma DS naming).
 $color-semantic-content-primary: var(--contents-content-primary, $color-content-default);
 $color-semantic-action-primary-default: var(--actions-action-primary-default, $color-primary);
 $color-semantic-feedback-negative: var(--feedback-negative, $color-negative);
 $color-semantic-border-actions: var(--borders-border-actions, $color-border-2);
 $color-semantic-surface-papers: var(--surfaces-surface-papers, $color-surface-0);
-
-//Actions
-$color-hover: var(--color-hover, rgba(0, 0, 0, 0.08));
-$color-pressed: var(--color-pressed, rgba(0, 0, 0, 0.16));
-$color-positive: var(--color-positive, #10603b);
-$color-negative: var(--color-negative, #e60f0f);
 
 //Extended
 $color-extended-blue: var(--color-extended-blue, $color-light-extended-blue);

--- a/src/globals/_colors.scss
+++ b/src/globals/_colors.scss
@@ -31,6 +31,13 @@ $color-delete: var(--color-delete, $color-light-delete);
 $color-shadow-0: var(--color-shadow-0, rgba(0, 0, 0, 0.04));
 $color-shadow-1: var(--color-shadow-1, rgba(0, 0, 0, 0.16));
 
+// Semantic token compatibility layer (Figma DS naming).
+$color-semantic-content-primary: var(--contents-content-primary, $color-content-default);
+$color-semantic-action-primary-default: var(--actions-action-primary-default, $color-primary);
+$color-semantic-feedback-negative: var(--feedback-negative, $color-negative);
+$color-semantic-border-actions: var(--borders-border-actions, $color-border-2);
+$color-semantic-surface-papers: var(--surfaces-surface-papers, $color-surface-0);
+
 //Actions
 $color-hover: var(--color-hover, rgba(0, 0, 0, 0.08));
 $color-pressed: var(--color-pressed, rgba(0, 0, 0, 0.16));


### PR DESCRIPTION
## Summary
- adds semantic color alias compatibility layer in theme variables
- migrates high-usage components to semantic aliases (content/action/border/feedback)
- preserves backwards compatibility via existing legacy token fallbacks

## Components updated
- input family, button, tabs, select/select-option, autocomplete
- upload, checkbox, radio, sidebar, tooltip, toast, banner, accordion
- alert-header, typo, skeleton, chip-clickable, menu-exibition

## Validation
- verified no SCSS diagnostics errors in changed files
- manual migration focused only on color token references

## Notes
- no documentation updates were required for this internal token alias migration