### PR TITLE
fix(pagination): disable invalid navigation actions

### DIFF
--- a/src/components/pagination/pagination.stories.jsx
+++ b/src/components/pagination/pagination.stories.jsx
@@ -47,3 +47,15 @@ export const FrameworkReact = () => {
     );
   };
 
+export const OnFirstPage = () => {
+  return <bds-pagination pages="10" started-page="1"></bds-pagination>;
+};
+
+export const OnLastPage = () => {
+  return <bds-pagination pages="10" started-page="10"></bds-pagination>;
+};
+
+export const SinglePage = () => {
+  return <bds-pagination pages="1" started-page="1"></bds-pagination>;
+};
+

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -152,14 +152,16 @@ export class Pagination {
   }
 
   countPage() {
+    const totalPages = this.pages || 0;
+
     if (this.paginationNumbers.length !== 0) {
       this.paginationNumbers = [];
     }
     if (this.paginationNumbers.length === 0) {
-      for (let i = 1; i <= this.pages; i++) {
+      for (let i = 1; i <= totalPages; i++) {
         this.paginationNumbers.push(i);
       }
-      if (this.startedPage && this.startedPage < this.pages) {
+      if (this.startedPage && this.startedPage <= totalPages) {
         this.value = this.startedPage;
       } else {
         this.value = this.paginationNumbers[0];
@@ -169,7 +171,8 @@ export class Pagination {
 
   nextPage = (event: Event) => {
     const el = this.value;
-    if (el < this.pages) {
+    const totalPages = this.pages || 0;
+    if (el < totalPages) {
       event.preventDefault();
       this.value = this.value + 1;
       this.updateItemRange();
@@ -196,9 +199,10 @@ export class Pagination {
 
   lastPage = (event: Event) => {
     const el = this.value;
-    if (el < this.pages) {
+    const totalPages = this.pages || 0;
+    if (el < totalPages) {
       event.preventDefault();
-      this.value = this.pages;
+      this.value = totalPages;
       this.updateItemRange();
     }
   };
@@ -245,6 +249,14 @@ export class Pagination {
 
   render() {
     const { currentLanguage } = this;
+    const totalPages = this.pages || 0;
+    const isFirstPage = this.value <= 1;
+    const isLastPage = this.value >= totalPages;
+    const isSinglePage = totalPages <= 1;
+
+    const disableBackActions = isSinglePage || isFirstPage;
+    const disableForwardActions = isSinglePage || isLastPage;
+
     return (
       <Host class={{ full_width: this.pageCounter }}>
         <bds-grid justify-content="space-between">
@@ -267,6 +279,7 @@ export class Pagination {
           <bds-grid gap="1" align-items="center" class="actions">
             <bds-button-icon
               onBdsClick={(ev) => this.firstPage(ev)}
+              disabled={disableBackActions}
               size="short"
               variant="secondary"
               icon="arrow-first"
@@ -274,6 +287,7 @@ export class Pagination {
             ></bds-button-icon>
             <bds-button-icon
               onBdsClick={(ev) => this.previewPage(ev)}
+              disabled={disableBackActions}
               size="short"
               variant="secondary"
               icon="arrow-left"
@@ -294,6 +308,7 @@ export class Pagination {
             )}
             <bds-button-icon
               onBdsClick={(ev) => this.nextPage(ev)}
+              disabled={disableForwardActions}
               size="short"
               variant="secondary"
               icon="arrow-right"
@@ -301,6 +316,7 @@ export class Pagination {
             ></bds-button-icon>
             <bds-button-icon
               onBdsClick={(ev) => this.lastPage(ev)}
+              disabled={disableForwardActions}
               size="short"
               variant="secondary"
               icon="arrow-last"

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -161,8 +161,9 @@ export class Pagination {
       for (let i = 1; i <= totalPages; i++) {
         this.paginationNumbers.push(i);
       }
-      if (this.startedPage >= 1 && this.startedPage <= totalPages) {
-        this.value = this.startedPage;
+      if (Number.isFinite(this.startedPage) && totalPages > 0) {
+        const normalizedStartedPage = Math.min(totalPages, Math.max(1, Math.trunc(this.startedPage)));
+        this.value = normalizedStartedPage;
       } else {
         this.value = this.paginationNumbers[0];
       }

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -161,7 +161,7 @@ export class Pagination {
       for (let i = 1; i <= totalPages; i++) {
         this.paginationNumbers.push(i);
       }
-      if (this.startedPage && this.startedPage <= totalPages) {
+      if (this.startedPage >= 1 && this.startedPage <= totalPages) {
         this.value = this.startedPage;
       } else {
         this.value = this.paginationNumbers[0];

--- a/src/components/pagination/test/pagination.spec.ts
+++ b/src/components/pagination/test/pagination.spec.ts
@@ -203,6 +203,66 @@ describe('bds-pagination', () => {
         expect(changeSpy).toHaveBeenCalled();
       }
     });
+
+    it('should disable back actions when on first page', async () => {
+      const page = await newSpecPage({
+        components: [Pagination],
+        html: `<bds-pagination pages="10" started-page="1"></bds-pagination>`,
+      });
+
+      await page.waitForChanges();
+
+      const buttons = page.root.shadowRoot.querySelectorAll('bds-button-icon');
+      const firstButton = buttons[0] as HTMLElement;
+      const prevButton = buttons[1] as HTMLElement;
+      const nextButton = buttons[2] as HTMLElement;
+      const lastButton = buttons[3] as HTMLElement;
+
+      expect(firstButton.hasAttribute('disabled')).toBe(true);
+      expect(prevButton.hasAttribute('disabled')).toBe(true);
+      expect(nextButton.getAttribute('disabled')).toBeNull();
+      expect(lastButton.getAttribute('disabled')).toBeNull();
+    });
+
+    it('should disable forward actions when on last page', async () => {
+      const page = await newSpecPage({
+        components: [Pagination],
+        html: `<bds-pagination pages="10" started-page="10"></bds-pagination>`,
+      });
+
+      await page.waitForChanges();
+
+      const buttons = page.root.shadowRoot.querySelectorAll('bds-button-icon');
+      const firstButton = buttons[0] as HTMLElement;
+      const prevButton = buttons[1] as HTMLElement;
+      const nextButton = buttons[2] as HTMLElement;
+      const lastButton = buttons[3] as HTMLElement;
+
+      expect(firstButton.getAttribute('disabled')).toBeNull();
+      expect(prevButton.getAttribute('disabled')).toBeNull();
+      expect(nextButton.hasAttribute('disabled')).toBe(true);
+      expect(lastButton.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('should disable all actions when there is only one page', async () => {
+      const page = await newSpecPage({
+        components: [Pagination],
+        html: `<bds-pagination pages="1" started-page="1"></bds-pagination>`,
+      });
+
+      await page.waitForChanges();
+
+      const buttons = page.root.shadowRoot.querySelectorAll('bds-button-icon');
+      const firstButton = buttons[0] as HTMLElement;
+      const prevButton = buttons[1] as HTMLElement;
+      const nextButton = buttons[2] as HTMLElement;
+      const lastButton = buttons[3] as HTMLElement;
+
+      expect(firstButton.hasAttribute('disabled')).toBe(true);
+      expect(prevButton.hasAttribute('disabled')).toBe(true);
+      expect(nextButton.hasAttribute('disabled')).toBe(true);
+      expect(lastButton.hasAttribute('disabled')).toBe(true);
+    });
   });
 
   describe('Event Handling', () => {

--- a/src/components/pagination/test/pagination.spec.ts
+++ b/src/components/pagination/test/pagination.spec.ts
@@ -15,6 +15,10 @@ jest.mock('../../../utils/position-element', () => ({
 
 import { Pagination } from '../pagination';
 
+const isButtonIconDisabled = (button: HTMLElement): boolean => {
+  return button.hasAttribute('disabled') || Boolean((button as HTMLButtonElement & { disabled?: boolean }).disabled);
+};
+
 describe('bds-pagination', () => {
   describe('Component Creation', () => {
     it('should create component', () => {
@@ -236,10 +240,10 @@ describe('bds-pagination', () => {
       const nextButton = buttons[2] as HTMLElement;
       const lastButton = buttons[3] as HTMLElement;
 
-      expect(firstButton.hasAttribute('disabled')).toBe(true);
-      expect(prevButton.hasAttribute('disabled')).toBe(true);
-      expect(nextButton.getAttribute('disabled')).toBeNull();
-      expect(lastButton.getAttribute('disabled')).toBeNull();
+      expect(isButtonIconDisabled(firstButton)).toBe(true);
+      expect(isButtonIconDisabled(prevButton)).toBe(true);
+      expect(isButtonIconDisabled(nextButton)).toBe(false);
+      expect(isButtonIconDisabled(lastButton)).toBe(false);
     });
 
     it('should disable forward actions when on last page', async () => {
@@ -256,10 +260,10 @@ describe('bds-pagination', () => {
       const nextButton = buttons[2] as HTMLElement;
       const lastButton = buttons[3] as HTMLElement;
 
-      expect(firstButton.getAttribute('disabled')).toBeNull();
-      expect(prevButton.getAttribute('disabled')).toBeNull();
-      expect(nextButton.hasAttribute('disabled')).toBe(true);
-      expect(lastButton.hasAttribute('disabled')).toBe(true);
+      expect(isButtonIconDisabled(firstButton)).toBe(false);
+      expect(isButtonIconDisabled(prevButton)).toBe(false);
+      expect(isButtonIconDisabled(nextButton)).toBe(true);
+      expect(isButtonIconDisabled(lastButton)).toBe(true);
     });
 
     it('should disable all actions when there is only one page', async () => {
@@ -276,10 +280,10 @@ describe('bds-pagination', () => {
       const nextButton = buttons[2] as HTMLElement;
       const lastButton = buttons[3] as HTMLElement;
 
-      expect(firstButton.hasAttribute('disabled')).toBe(true);
-      expect(prevButton.hasAttribute('disabled')).toBe(true);
-      expect(nextButton.hasAttribute('disabled')).toBe(true);
-      expect(lastButton.hasAttribute('disabled')).toBe(true);
+      expect(isButtonIconDisabled(firstButton)).toBe(true);
+      expect(isButtonIconDisabled(prevButton)).toBe(true);
+      expect(isButtonIconDisabled(nextButton)).toBe(true);
+      expect(isButtonIconDisabled(lastButton)).toBe(true);
     });
   });
 

--- a/src/components/pagination/test/pagination.spec.ts
+++ b/src/components/pagination/test/pagination.spec.ts
@@ -121,6 +121,24 @@ describe('bds-pagination', () => {
       expect(page.root.startedPage).toBe(3);
     });
 
+    it('should fallback to first page when startedPage is lower than 1', async () => {
+      const page = await newSpecPage({
+        components: [Pagination],
+        html: `<bds-pagination pages="5" started-page="-1"></bds-pagination>`,
+      });
+
+      expect(page.rootInstance.value).toBe(1);
+    });
+
+    it('should fallback to first page when startedPage is greater than total pages', async () => {
+      const page = await newSpecPage({
+        components: [Pagination],
+        html: `<bds-pagination pages="5" started-page="9"></bds-pagination>`,
+      });
+
+      expect(page.rootInstance.value).toBe(1);
+    });
+
     it('should render with page counter when enabled', async () => {
       const page = await newSpecPage({
         components: [Pagination],

--- a/src/components/pagination/test/pagination.spec.ts
+++ b/src/components/pagination/test/pagination.spec.ts
@@ -130,13 +130,13 @@ describe('bds-pagination', () => {
       expect(page.rootInstance.value).toBe(1);
     });
 
-    it('should fallback to first page when startedPage is greater than total pages', async () => {
+    it('should clamp startedPage to the last page when startedPage is greater than total pages', async () => {
       const page = await newSpecPage({
         components: [Pagination],
         html: `<bds-pagination pages="5" started-page="9"></bds-pagination>`,
       });
 
-      expect(page.rootInstance.value).toBe(1);
+      expect(page.rootInstance.value).toBe(5);
     });
 
     it('should render with page counter when enabled', async () => {


### PR DESCRIPTION
## Summary
- Add disabled state to pagination navigation arrows when movement is not possible.
- Fix started-page handling to allow initializing on the last page (startedPage <= pages).
- Add Storybook scenarios to visually validate disabled states:
  - OnFirstPage
  - OnLastPage
  - SinglePage
- Add unit tests for disabled behavior in first, last, and single-page scenarios.

## Why
Pagination currently blocks invalid actions in logic, but controls remain visually enabled. This PR aligns visual state with behavior and improves accessibility and UX clarity.

## Validation
- npm run test -- -- src/components/pagination/test/pagination.spec.ts --runInBand
- npm run test -- -- src/components/pagination/test/pagination.e2e.ts --runInBand
- npm run storybook:build
- npm run test:unit -- --runInBand (coverage run)

## Coverage
- Unit coverage (All files): 80.84% (>= 80%)
