### PR TITLE
feat: breadcrumb stylization AB#1033048 

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -360,7 +360,7 @@ export namespace Components {
     }
     interface BdsBreadcrumb {
         "items": string | Array<{ label: string; href?: string }>;
-        "wrapItems": boolean | string;
+        "wrapItems": boolean;
     }
     interface BdsButton {
         /**
@@ -4212,7 +4212,7 @@ declare namespace LocalJSX {
     }
     interface BdsBreadcrumb {
         "items"?: string | Array<{ label: string; href?: string }>;
-        "wrapItems"?: boolean | string;
+        "wrapItems"?: boolean;
     }
     interface BdsButton {
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -360,9 +360,6 @@ export namespace Components {
     }
     interface BdsBreadcrumb {
         "items": string | Array<{ label: string; href?: string }>;
-        /**
-          * @default true
-         */
         "wrapItems": boolean | string;
     }
     interface BdsButton {
@@ -4215,9 +4212,6 @@ declare namespace LocalJSX {
     }
     interface BdsBreadcrumb {
         "items"?: string | Array<{ label: string; href?: string }>;
-        /**
-          * @default true
-         */
         "wrapItems"?: boolean | string;
     }
     interface BdsButton {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -360,6 +360,10 @@ export namespace Components {
     }
     interface BdsBreadcrumb {
         "items": string | Array<{ label: string; href?: string }>;
+        /**
+          * @default true
+         */
+        "wrapItems": boolean | string;
     }
     interface BdsButton {
         /**
@@ -4211,6 +4215,10 @@ declare namespace LocalJSX {
     }
     interface BdsBreadcrumb {
         "items"?: string | Array<{ label: string; href?: string }>;
+        /**
+          * @default true
+         */
+        "wrapItems"?: boolean | string;
     }
     interface BdsButton {
         /**

--- a/src/components/breadcrumb/breadcrumb.scss
+++ b/src/components/breadcrumb/breadcrumb.scss
@@ -44,3 +44,28 @@
 .breadcrumb__link {
   text-decoration: none;
 }
+
+.breadcrumb__item {
+  transition: color 0.15s, background-color 0.15s;
+
+  bds-typo, bds-icon, .breadcrumb__text {
+    color: $color-content-ghost;
+
+  }
+
+  bds-typo:hover, .breadcrumb__text:hover {
+    color: $color-content-default;
+  }
+
+  &--active {
+    border-radius: 12px;
+
+    &:hover {
+      background-color: $color-surface-3;
+    }
+
+    bds-typo, bds-icon, .breadcrumb__text {
+      color: $color-content-default;
+    }
+  }
+}

--- a/src/components/breadcrumb/breadcrumb.stories.jsx
+++ b/src/components/breadcrumb/breadcrumb.stories.jsx
@@ -18,9 +18,11 @@ export const Properties = (args) => {
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    // ensure items is passed as the expected type (string or array) and wrapItems as boolean
+    // keep component defaults unless args explicitly provides a wrapItems value
     el.items = args.items;
-    el.wrapItems = !!args.wrapItems;
+    if (args.wrapItems !== undefined) {
+      el.wrapItems = args.wrapItems;
+    }
   }, [args.items, args.wrapItems]);
 
   return <bds-breadcrumb ref={ref}></bds-breadcrumb>;
@@ -38,7 +40,7 @@ Properties.argTypes = {
     table: {
       defaultValue: { summary: 'true' },
     },
-    description: 'Determines if breadcrumb items should wrap to the next line when they exceed the container width.',
+    description: 'Determines if middle items collapse into a dropdown when there are more than 3 breadcrumb items.',
     control: 'boolean',
   },
 };

--- a/src/components/breadcrumb/breadcrumb.stories.jsx
+++ b/src/components/breadcrumb/breadcrumb.stories.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import DocumentationTemplate from './breadcrumb.mdx';
 import { BdsBreadcrumb } from '../../../blip-ds-react/dist/components';
 
@@ -13,11 +13,17 @@ export default {
 };
 
 export const Properties = (args) => {
-  return (
-    <bds-breadcrumb
-      items={args.items}
-    ></bds-breadcrumb>
-  );
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    // ensure items is passed as the expected type (string or array) and wrapItems as boolean
+    el.items = args.items;
+    el.wrapItems = !!args.wrapItems;
+  }, [args.items, args.wrapItems]);
+
+  return <bds-breadcrumb ref={ref}></bds-breadcrumb>;
 };
 
 Properties.argTypes = {
@@ -28,6 +34,13 @@ Properties.argTypes = {
     description: 'Define the labels and hrefs for the breadcrumb items.',
     control: { type: 'text' },
   },
+  wrapItems: {
+    table: {
+      defaultValue: { summary: 'true' },
+    },
+    description: 'Determines if breadcrumb items should wrap to the next line when they exceed the container width.',
+    control: 'boolean',
+  },
 };
 
 Properties.args = {
@@ -35,7 +48,7 @@ Properties.args = {
     { label: 'Home', href: '/' },
     { label: 'About', href: '/about' },
     { label: 'Contact', href: '/contact' },
-    { label: 'Current Page' },
+    { label: 'Current Page', href: '/current' },
   ]),
 };
 
@@ -58,6 +71,7 @@ export const Events = () => {
           { label: 'Documentation' },
         ])}
         onBreadcrumbItemClick={(event) => handleBreadcrumbClick(event)}
+        wrap-items={true}
       ></bds-breadcrumb>
       {clickedItem && (
         <div>
@@ -85,6 +99,7 @@ export const FrameworkReact = () => {
         { label: 'Pricing', href: '/pricing' },
         { label: 'Documentation' },
       ]}
+      wrapItems={true}
     />
   );
 };

--- a/src/components/breadcrumb/breadcrumb.stories.jsx
+++ b/src/components/breadcrumb/breadcrumb.stories.jsx
@@ -56,6 +56,21 @@ Properties.args = {
 
 export const Events = () => {
   const [clickedItem, setClickedItem] = useState(null);
+  const ref = useRef(null);
+
+  const items = [
+    { label: 'Home', href: '/' },
+    { label: 'Features', href: '/features' },
+    { label: 'Pricing', href: '/pricing' },
+    { label: 'Documentation' },
+  ];
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.items = JSON.stringify(items);
+    el.wrapItems = true;
+  }, []);
 
   const handleBreadcrumbClick = (event) => {
     const detail = event.detail;
@@ -66,14 +81,8 @@ export const Events = () => {
   return (
     <div>
       <bds-breadcrumb
-        items={JSON.stringify([
-          { label: 'Home', href: '/' },
-          { label: 'Features', href: '/features' },
-          { label: 'Pricing', href: '/pricing' },
-          { label: 'Documentation' },
-        ])}
+        ref={ref}
         onBreadcrumbItemClick={(event) => handleBreadcrumbClick(event)}
-        wrap-items={true}
       ></bds-breadcrumb>
       {clickedItem && (
         <div>

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -30,6 +30,7 @@ export class Breadcrumb {
       try {
         this.parsedItems = JSON.parse(newValue);
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.warn('[bds-breadcrumb] Failed to parse items:', error);
         this.parsedItems = [];
       }
@@ -121,7 +122,7 @@ export class Breadcrumb {
       >
         {item.label}
       </bds-typo>
-    )
+    );
   }
 
   private renderBreadcrumbItem(item: { label: string; href?: string | null }, index: number, items: Array<{ label: string; href?: string | null }>) {
@@ -143,7 +144,7 @@ export class Breadcrumb {
         </bds-grid>
         {!isLastItem && <bds-icon name="arrow-right" size="medium" class="breadcrumb__text"></bds-icon>}
       </bds-grid>
-    )
+    );
   }
 
   componentWillLoad() {

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -6,7 +6,7 @@ import { Component, h, Prop, State, Watch, Element } from '@stencil/core';
   shadow: true,
 })
 export class Breadcrumb {
-  @Element() hostElement: HTMLElement;
+  @Element() hostElement!: HTMLElement;
   @Prop() items: string | Array<{ label: string; href?: string }> = [];
 
   @Prop() wrapItems: boolean | string = true;
@@ -29,6 +29,16 @@ export class Breadcrumb {
   @State() parsedItems: Array<{ label: string; href?: string }> = [];
 
   @State() isDropdownOpen: boolean = false;
+
+  private handleDropdownToggle = (event: CustomEvent<{ value: boolean }>) => {
+    const nextOpen = !!event?.detail?.value;
+    if (nextOpen === this.isDropdownOpen) return;
+    this.isDropdownOpen = nextOpen;
+  };
+
+  private handleActivatorPointer = (event: MouseEvent) => {
+    event.stopPropagation();
+  };
 
   @Watch('items')
   parseItems(newValue: string | Array<{ label: string; href?: string }>) {
@@ -62,10 +72,6 @@ export class Breadcrumb {
     }
   }
 
-  toggleDropdown() {
-    this.isDropdownOpen = !this.isDropdownOpen;
-  }
-
   render() {
     if (!this.parsedItems || this.parsedItems.length === 0) {
       return <p>Sem itens para exibir no Breadcrumb.</p>;
@@ -86,7 +92,11 @@ export class Breadcrumb {
 
         if (item.label === '...') {
           return (
-            <bds-dropdown active-mode="click" position="auto" open={this.isDropdownOpen}>
+            <bds-dropdown
+              position="auto"
+              open={this.isDropdownOpen}
+              onBdsToggle={this.handleDropdownToggle}
+            >
               <bds-grid slot="dropdown-content">
                 <bds-grid direction="column" padding="1" gap="half">
                   {this.parsedItems.slice(1, -1).map((subItem, idx) => (
@@ -94,7 +104,7 @@ export class Breadcrumb {
                       {subItem.href ? (
                         <a
                           href={subItem.href}
-                          class={`breadcrumb__link breadcrumb__button--${idx}`}
+                          style={{ textDecoration: 'none' }}
                         >
                           <bds-grid align-items="center" gap="half">
                             <bds-icon
@@ -103,13 +113,9 @@ export class Breadcrumb {
                               class="button--icon"
                               size="x-small"
                             ></bds-icon>
-                            <bds-button
-                              variant="text"
-                              color="content"
-                              size="short"
-                            >
+                            <bds-typo variant="fs-16" margin={false} class="breadcrumb__text">
                               {subItem.label}
-                            </bds-button>
+                            </bds-typo>
                           </bds-grid>
                         </a>
                       ) : (
@@ -124,8 +130,9 @@ export class Breadcrumb {
                   variant="text"
                   color="content"
                   size="short"
-                  onClick={() => this.toggleDropdown()}
                   icon-left="more-options-horizontal"
+                  onMouseDown={this.handleActivatorPointer}
+                  onClick={this.handleActivatorPointer}
                 ></bds-button>
               </bds-grid>
             </bds-dropdown>

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, State, Watch, Element } from '@stencil/core';
+import { Component, h, Prop, State, Watch } from '@stencil/core';
 
 @Component({
   tag: 'bds-breadcrumb',
@@ -6,25 +6,9 @@ import { Component, h, Prop, State, Watch, Element } from '@stencil/core';
   shadow: true,
 })
 export class Breadcrumb {
-  @Element() hostElement!: HTMLElement;
   @Prop() items: string | Array<{ label: string; href?: string }> = [];
 
-  @Prop() wrapItems: boolean | string = true;
-
-  // internal normalized boolean value to avoid re-assigning the prop inside its watcher
-  private wrapItemsBool: boolean = true;
-
-  @Watch('wrapItems')
-  handleWrapItemsChange(newValue: boolean | string) {
-    if (typeof newValue === 'string') {
-      if (newValue === 'true') this.wrapItemsBool = true;
-      else if (newValue === 'false') this.wrapItemsBool = false;
-      else if (newValue === '') this.wrapItemsBool = true; // presence-only attribute => true
-      else this.wrapItemsBool = !!newValue;
-    } else {
-      this.wrapItemsBool = !!newValue;
-    }
-  }
+  @Prop() wrapItems: boolean = true;
 
   @State() parsedItems: Array<{ label: string; href?: string }> = [];
 
@@ -45,7 +29,8 @@ export class Breadcrumb {
     if (typeof newValue === 'string') {
       try {
         this.parsedItems = JSON.parse(newValue);
-      } catch {
+      } catch (error) {
+        console.warn('[bds-breadcrumb] Failed to parse items:', error);
         this.parsedItems = [];
       }
     } else {
@@ -53,23 +38,116 @@ export class Breadcrumb {
     }
   }
 
+  private renderCollapsedDropdown() {
+    return (
+      <bds-dropdown
+        position="auto"
+        open={this.isDropdownOpen}
+        onBdsToggle={this.handleDropdownToggle}
+      >
+        <bds-grid slot="dropdown-content">
+          <bds-grid direction="column" padding="1" gap="half">
+            {this.parsedItems.slice(1, -1).map((subItem, idx) => (
+              <bds-grid class={`breadcrumb__button--${idx}`} key={subItem.label + idx}>
+                {subItem.href ? (
+                  <a
+                    href={subItem.href}
+                    class="breadcrumb__link"
+                  >
+                    <bds-grid align-items="center" gap="half">
+                      <bds-icon
+                        name="reply"
+                        theme="outline"
+                        class="button--icon"
+                        size="x-small"
+                      ></bds-icon>
+                      <bds-typo variant="fs-16" margin={false} class="breadcrumb__text">
+                        {subItem.label}
+                      </bds-typo>
+                    </bds-grid>
+                  </a>
+                ) : (
+                  <span>{subItem.label}</span>
+                )}
+              </bds-grid>
+            ))}
+          </bds-grid>
+        </bds-grid>
+        <bds-grid slot="dropdown-activator" align-items="center">
+          <bds-button
+            variant="text"
+            color="content"
+            size="short"
+            icon-left="more-options-horizontal"
+            onMouseDown={this.handleActivatorPointer}
+            onClick={this.handleActivatorPointer}
+            aria-label="Mostrar itens ocultos do breadcrumb"
+          ></bds-button>
+        </bds-grid>
+      </bds-dropdown>
+    );
+  }
+
+  private renderItemContent(item: { label: string; href?: string | null }, isCurrent: boolean) {
+    if (item.label === '...') {
+      return this.renderCollapsedDropdown();
+    }
+
+    if (item.href) {
+      return (
+        <bds-typo
+          variant="fs-20"
+          margin={false}
+          class="breadcrumb__link--text"
+        >
+          <a
+            href={item.href}
+            class="breadcrumb__link breadcrumb__text"
+            aria-current={isCurrent ? 'page' : null}
+          >
+            {item.label}
+          </a>
+        </bds-typo>
+      );
+    }
+
+    return (
+      <bds-typo
+        variant="fs-20"
+        bold={isCurrent ? 'bold' : 'regular'}
+        margin={false}
+        class="breadcrumb__text"
+        aria-current={isCurrent ? 'page' : null}
+      >
+        {item.label}
+      </bds-typo>
+    )
+  }
+
+  private renderBreadcrumbItem(item: { label: string; href?: string | null }, index: number, items: Array<{ label: string; href?: string | null }>) {
+    const isLastItem = index === items.length - 1;
+
+    return (
+      <bds-grid
+        class={{
+          breadcrumb__item: true,
+          'breadcrumb__item--active': isLastItem,
+        }}
+        key={item.label + index}
+        align-items="center"
+      >
+        <bds-grid direction="row" align-items="center" padding="x-1">
+          <bds-grid direction="row" align-items="center" padding="y-half">
+            {this.renderItemContent(item, isLastItem)}
+          </bds-grid>
+        </bds-grid>
+        {!isLastItem && <bds-icon name="arrow-right" size="medium" class="breadcrumb__text"></bds-icon>}
+      </bds-grid>
+    )
+  }
+
   componentWillLoad() {
     this.parseItems(this.items);
-    // Normalize initial wrapItems value with preference for explicit attribute
-    const attr = this.hostElement.getAttribute('wrap-items');
-    if (attr === null) {
-      // attribute absent — use the prop value (could be boolean or string)
-      this.handleWrapItemsChange(this.wrapItems);
-    } else if (attr === '') {
-      // presence-only attribute means true
-      this.wrapItemsBool = true;
-    } else if (attr === 'false') {
-      this.wrapItemsBool = false;
-    } else if (attr === 'true') {
-      this.wrapItemsBool = true;
-    } else {
-      this.wrapItemsBool = !!attr;
-    }
   }
 
   render() {
@@ -77,113 +155,19 @@ export class Breadcrumb {
       return <p>Sem itens para exibir no Breadcrumb.</p>;
     }
 
-    const visibleItems =
-      this.wrapItemsBool && this.parsedItems.length > 3
+    const visibleItems: Array<{ label: string; href?: string | null }> =
+      this.wrapItems && this.parsedItems.length > 3
         ? [
-          this.parsedItems[0],
-          { label: '...', href: null },
-          this.parsedItems[this.parsedItems.length - 1],
-        ]
+            this.parsedItems[0],
+            { label: '...', href: undefined },
+            this.parsedItems[this.parsedItems.length - 1],
+          ]
         : this.parsedItems;
-
-    const renderBreadcrumbItem = (item: { label: string; href?: string | null }, index: number) => {
-      const isLastItem = index === visibleItems.length - 1;
-      const renderBasedOnLabel = (item: { label: string; href?: string | null }) => {
-
-        if (item.label === '...') {
-          return (
-            <bds-dropdown
-              position="auto"
-              open={this.isDropdownOpen}
-              onBdsToggle={this.handleDropdownToggle}
-            >
-              <bds-grid slot="dropdown-content">
-                <bds-grid direction="column" padding="1" gap="half">
-                  {this.parsedItems.slice(1, -1).map((subItem, idx) => (
-                    <bds-grid class={`breadcrumb__button--${idx}`} key={subItem.label + idx}>
-                      {subItem.href ? (
-                        <a
-                          href={subItem.href}
-                          style={{ textDecoration: 'none' }}
-                        >
-                          <bds-grid align-items="center" gap="half">
-                            <bds-icon
-                              name="reply"
-                              theme="outline"
-                              class="button--icon"
-                              size="x-small"
-                            ></bds-icon>
-                            <bds-typo variant="fs-16" margin={false} class="breadcrumb__text">
-                              {subItem.label}
-                            </bds-typo>
-                          </bds-grid>
-                        </a>
-                      ) : (
-                        <span>{subItem.label}</span>
-                      )}
-                    </bds-grid>
-                  ))}
-                </bds-grid>
-              </bds-grid>
-              <bds-grid slot="dropdown-activator" align-items="center">
-                <bds-button
-                  variant="text"
-                  color="content"
-                  size="short"
-                  icon-left="more-options-horizontal"
-                  onMouseDown={this.handleActivatorPointer}
-                  onClick={this.handleActivatorPointer}
-                ></bds-button>
-              </bds-grid>
-            </bds-dropdown>
-          );
-        }
-
-        if (item.href) {
-          return (
-            <bds-typo
-              variant="fs-20"
-              margin={false}
-              class="breadcrumb__link--text"
-            >
-              <a href={item.href} class="breadcrumb__link breadcrumb__text">
-                {item.label}
-              </a>
-            </bds-typo>
-          );
-        }
-
-        return (
-          <bds-typo variant="fs-20" bold={isLastItem ? 'bold' : 'regular'} margin={false} class="breadcrumb__text">
-            {item.label}
-          </bds-typo>
-        )
-      }
-
-      return (
-        <bds-grid
-          class={{
-            breadcrumb__item: true,
-            'breadcrumb__item--active': isLastItem,
-          }}
-          aria-current={isLastItem ? 'page' : null}
-          key={item.label + index}
-          align-items="center"
-        >
-          <bds-grid direction="row" align-items="center" padding="x-1">
-            <bds-grid direction="row" align-items="center" padding="y-half">
-              {renderBasedOnLabel(item)}
-            </bds-grid>
-          </bds-grid>
-          {!isLastItem && <bds-icon name="arrow-right" size="medium" class="breadcrumb__text"></bds-icon>}
-        </bds-grid>
-      )
-    }
 
     return (
       <nav aria-label="breadcrumb">
         <bds-grid direction="row" align-items="center">
-          {visibleItems.map((element, index) => renderBreadcrumbItem(element, index))}
+          {visibleItems.map((element, index) => this.renderBreadcrumbItem(element, index, visibleItems))}
         </bds-grid>
       </nav>
     );

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -86,7 +86,7 @@ export class Breadcrumb {
 
         if (item.label === '...') {
           return (
-            <bds-dropdown active-mode="click" position="auto">
+            <bds-dropdown active-mode="click" position="auto" open={this.isDropdownOpen}>
               <bds-grid slot="dropdown-content">
                 <bds-grid direction="column" padding="1" gap="half">
                   {this.parsedItems.slice(1, -1).map((subItem, idx) => (

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, State, Watch } from '@stencil/core';
+import { Component, h, Prop, State, Watch, Element } from '@stencil/core';
 
 @Component({
   tag: 'bds-breadcrumb',
@@ -6,7 +6,25 @@ import { Component, h, Prop, State, Watch } from '@stencil/core';
   shadow: true,
 })
 export class Breadcrumb {
+  @Element() hostElement: HTMLElement;
   @Prop() items: string | Array<{ label: string; href?: string }> = [];
+
+  @Prop() wrapItems: boolean | string = true;
+
+  // internal normalized boolean value to avoid re-assigning the prop inside its watcher
+  private wrapItemsBool: boolean = true;
+
+  @Watch('wrapItems')
+  handleWrapItemsChange(newValue: boolean | string) {
+    if (typeof newValue === 'string') {
+      if (newValue === 'true') this.wrapItemsBool = true;
+      else if (newValue === 'false') this.wrapItemsBool = false;
+      else if (newValue === '') this.wrapItemsBool = true; // presence-only attribute => true
+      else this.wrapItemsBool = !!newValue;
+    } else {
+      this.wrapItemsBool = !!newValue;
+    }
+  }
 
   @State() parsedItems: Array<{ label: string; href?: string }> = [];
 
@@ -17,7 +35,7 @@ export class Breadcrumb {
     if (typeof newValue === 'string') {
       try {
         this.parsedItems = JSON.parse(newValue);
-      } catch (error) {
+      } catch {
         this.parsedItems = [];
       }
     } else {
@@ -27,6 +45,21 @@ export class Breadcrumb {
 
   componentWillLoad() {
     this.parseItems(this.items);
+    // Normalize initial wrapItems value with preference for explicit attribute
+    const attr = this.hostElement.getAttribute('wrap-items');
+    if (attr === null) {
+      // attribute absent — use the prop value (could be boolean or string)
+      this.handleWrapItemsChange(this.wrapItems);
+    } else if (attr === '') {
+      // presence-only attribute means true
+      this.wrapItemsBool = true;
+    } else if (attr === 'false') {
+      this.wrapItemsBool = false;
+    } else if (attr === 'true') {
+      this.wrapItemsBool = true;
+    } else {
+      this.wrapItemsBool = !!attr;
+    }
   }
 
   toggleDropdown() {
@@ -39,92 +72,111 @@ export class Breadcrumb {
     }
 
     const visibleItems =
-      this.parsedItems.length <= 3
-        ? this.parsedItems
-        : [
-            this.parsedItems[0],
-            { label: '...', href: null },
-            this.parsedItems[this.parsedItems.length - 1],
-          ];
+      this.wrapItemsBool && this.parsedItems.length > 3
+        ? [
+          this.parsedItems[0],
+          { label: '...', href: null },
+          this.parsedItems[this.parsedItems.length - 1],
+        ]
+        : this.parsedItems;
+
+    const renderBreadcrumbItem = (item: { label: string; href?: string | null }, index: number) => {
+      const isLastItem = index === visibleItems.length - 1;
+      const renderBasedOnLabel = (item: { label: string; href?: string | null }) => {
+
+        if (item.label === '...') {
+          return (
+            <bds-dropdown active-mode="click" position="auto">
+              <bds-grid slot="dropdown-content">
+                <bds-grid direction="column" padding="1" gap="half">
+                  {this.parsedItems.slice(1, -1).map((subItem, idx) => (
+                    <bds-grid class={`breadcrumb__button--${idx}`} key={subItem.label + idx}>
+                      {subItem.href ? (
+                        <a
+                          href={subItem.href}
+                          class={`breadcrumb__link breadcrumb__button--${idx}`}
+                        >
+                          <bds-grid align-items="center" gap="half">
+                            <bds-icon
+                              name="reply"
+                              theme="outline"
+                              class="button--icon"
+                              size="x-small"
+                            ></bds-icon>
+                            <bds-button
+                              variant="text"
+                              color="content"
+                              size="short"
+                            >
+                              {subItem.label}
+                            </bds-button>
+                          </bds-grid>
+                        </a>
+                      ) : (
+                        <span>{subItem.label}</span>
+                      )}
+                    </bds-grid>
+                  ))}
+                </bds-grid>
+              </bds-grid>
+              <bds-grid slot="dropdown-activator" align-items="center">
+                <bds-button
+                  variant="text"
+                  color="content"
+                  size="short"
+                  onClick={() => this.toggleDropdown()}
+                  icon-left="more-options-horizontal"
+                ></bds-button>
+              </bds-grid>
+            </bds-dropdown>
+          );
+        }
+
+        if (item.href) {
+          return (
+            <bds-typo
+              variant="fs-20"
+              margin={false}
+              class="breadcrumb__link--text"
+            >
+              <a href={item.href} class="breadcrumb__link breadcrumb__text">
+                {item.label}
+              </a>
+            </bds-typo>
+          );
+        }
+
+        return (
+          <bds-typo variant="fs-20" bold={isLastItem ? 'bold' : 'regular'} margin={false} class="breadcrumb__text">
+            {item.label}
+          </bds-typo>
+        )
+      }
+
+      return (
+        <bds-grid
+          class={{
+            breadcrumb__item: true,
+            'breadcrumb__item--active': isLastItem,
+          }}
+          aria-current={isLastItem ? 'page' : null}
+          key={item.label + index}
+          align-items="center"
+        >
+          <bds-grid direction="row" align-items="center" padding="x-1">
+            <bds-grid direction="row" align-items="center" padding="y-half">
+              {renderBasedOnLabel(item)}
+            </bds-grid>
+          </bds-grid>
+          {!isLastItem && <bds-icon name="arrow-right" size="medium" class="breadcrumb__text"></bds-icon>}
+        </bds-grid>
+      )
+    }
 
     return (
       <nav aria-label="breadcrumb">
         <bds-grid direction="row" align-items="center">
-          {visibleItems.map((item, index) => (
-            <bds-grid
-              class={{
-                breadcrumb__item: true,
-                'breadcrumb__item--active': index === visibleItems.length - 1,
-              }}
-              aria-current={index === visibleItems.length - 1 ? 'page' : null}
-            >
-              {item.label === '...' ? (
-                <bds-dropdown active-mode="click" position="auto">
-                  <bds-grid slot="dropdown-content">
-                    <bds-grid direction="column" padding="1" gap="half">
-                      {this.parsedItems.slice(1, -1).map((subItem, idx) => (
-                        <bds-grid class={`breadcrumb__button--${idx}`}>
-                          {subItem.href ? (
-                            <a
-                              href={subItem.href}
-                              class={`breadcrumb__link breadcrumb__button--${idx}`}
-                            >
-                              <bds-grid align-items="center" gap="half">
-                                <bds-icon
-                                  name="reply"
-                                  theme="outline"
-                                  class="button--icon"
-                                  size="x-small"
-                                ></bds-icon>
-                                <bds-button
-                                  variant="text"
-                                  color="content"
-                                  size="short"
-                                >
-                                  {subItem.label}
-                                </bds-button>
-                              </bds-grid>
-                            </a>
-                          ) : (
-                            <span>{subItem.label}</span>
-                          )}
-                        </bds-grid>
-                      ))}
-                    </bds-grid>
-                  </bds-grid>
-                  <bds-grid slot="dropdown-activator" align-items="center">
-                    <bds-button
-                      variant="text"
-                      color="content"
-                      size="short"
-                      onClick={() => this.toggleDropdown()}
-                      icon-left="more-options-horizontal"
-                    ></bds-button>
-                    <bds-icon name="arrow-right" size="x-small"></bds-icon>
-                  </bds-grid>
-                </bds-dropdown>
-              ) : item.href ? (
-                <bds-grid direction="row">
-                  <bds-typo
-                    variant="fs-12"
-                    margin={false}
-                    class="breadcrumb__link--text"
-                  >
-                    <a href={item.href} class="breadcrumb__link">
-                      {item.label}
-                    </a>
-                  </bds-typo>
-                  <bds-icon name="arrow-right" size="x-small"></bds-icon>
-                </bds-grid>
-              ) : (
-                <bds-grid direction="row">
-                  <bds-typo variant="fs-12" bold="semi-bold" margin={false}>
-                    {item.label}
-                  </bds-typo>
-                </bds-grid>
-              )}
-            </bds-grid>
-          ))}
+          {visibleItems.map((element, index) => renderBreadcrumbItem(element, index))}
         </bds-grid>
       </nav>
     );

--- a/src/components/breadcrumb/readme.md
+++ b/src/components/breadcrumb/readme.md
@@ -10,7 +10,7 @@
 | Property    | Attribute    | Description | Type                                            | Default |
 | ----------- | ------------ | ----------- | ----------------------------------------------- | ------- |
 | `items`     | `items`      |             | `string \| { label: string; href?: string; }[]` | `[]`    |
-| `wrapItems` | `wrap-items` |             | `boolean \| string`                             | `true`  |
+| `wrapItems` | `wrap-items` |             | `boolean`                                       | `true`  |
 
 
 ## Dependencies

--- a/src/components/breadcrumb/readme.md
+++ b/src/components/breadcrumb/readme.md
@@ -7,17 +7,18 @@
 
 ## Properties
 
-| Property | Attribute | Description | Type                                            | Default |
-| -------- | --------- | ----------- | ----------------------------------------------- | ------- |
-| `items`  | `items`   |             | `string \| { label: string; href?: string; }[]` | `[]`    |
+| Property    | Attribute    | Description | Type                                            | Default |
+| ----------- | ------------ | ----------- | ----------------------------------------------- | ------- |
+| `items`     | `items`      |             | `string \| { label: string; href?: string; }[]` | `[]`    |
+| `wrapItems` | `wrap-items` |             | `boolean \| string`                             | `true`  |
 
 
 ## Dependencies
 
 ### Depends on
 
-- [bds-grid](../grid)
 - [bds-dropdown](../dropdown)
+- [bds-grid](../grid)
 - [bds-icon](../icon)
 - [bds-button](../button)
 - [bds-typo](../typo)
@@ -25,8 +26,8 @@
 ### Graph
 ```mermaid
 graph TD;
-  bds-breadcrumb --> bds-grid
   bds-breadcrumb --> bds-dropdown
+  bds-breadcrumb --> bds-grid
   bds-breadcrumb --> bds-icon
   bds-breadcrumb --> bds-button
   bds-breadcrumb --> bds-typo

--- a/src/components/breadcrumb/readme.md
+++ b/src/components/breadcrumb/readme.md
@@ -20,8 +20,8 @@
 - [bds-dropdown](../dropdown)
 - [bds-grid](../grid)
 - [bds-icon](../icon)
-- [bds-button](../button)
 - [bds-typo](../typo)
+- [bds-button](../button)
 
 ### Graph
 ```mermaid
@@ -29,8 +29,8 @@ graph TD;
   bds-breadcrumb --> bds-dropdown
   bds-breadcrumb --> bds-grid
   bds-breadcrumb --> bds-icon
-  bds-breadcrumb --> bds-button
   bds-breadcrumb --> bds-typo
+  bds-breadcrumb --> bds-button
   bds-button --> bds-loading-spinner
   bds-button --> bds-icon
   bds-button --> bds-typo

--- a/src/components/breadcrumb/test/breadcrumb.spec.ts
+++ b/src/components/breadcrumb/test/breadcrumb.spec.ts
@@ -162,7 +162,23 @@ describe('bds-breadcrumb', () => {
       expect(nav).toBeTruthy();
     });
 
-    it('collapses items when wrap-items is present (true)', async () => {
+    it('should not collapse when there are exactly 3 items and wrap-items is true', async () => {
+      const items = [
+        { label: 'Home', href: '/' },
+        { label: 'Category', href: '/category' },
+        { label: 'Current Page' },
+      ];
+      const page = await newSpecPage({
+        components: [Breadcrumb],
+        html: `<bds-breadcrumb items='${JSON.stringify(items)}' wrap-items="true"></bds-breadcrumb>`,
+      });
+
+      const sr = getShadowRoot(page);
+      expect(sr.querySelector('bds-dropdown')).toBeNull();
+      expect(sr.querySelectorAll('.breadcrumb__item').length).toBe(3);
+    });
+
+    it('should collapse when there are exactly 4 items and wrap-items is true', async () => {
       const items = [
         { label: 'Home', href: '/' },
         { label: 'About', href: '/about' },
@@ -172,6 +188,23 @@ describe('bds-breadcrumb', () => {
       const page = await newSpecPage({
         components: [Breadcrumb],
         html: `<bds-breadcrumb items='${JSON.stringify(items)}' wrap-items="true"></bds-breadcrumb>`,
+      });
+
+      const sr = getShadowRoot(page);
+      expect(sr.querySelector('bds-dropdown')).toBeTruthy();
+      expect(sr.querySelectorAll('.breadcrumb__item').length).toBe(3);
+    });
+
+    it('collapses items when wrap-items attribute is present without an explicit value', async () => {
+      const items = [
+        { label: 'Home', href: '/' },
+        { label: 'About', href: '/about' },
+        { label: 'Contact', href: '/contact' },
+        { label: 'Current Page' },
+      ];
+      const page = await newSpecPage({
+        components: [Breadcrumb],
+        html: `<bds-breadcrumb items='${JSON.stringify(items)}' wrap-items></bds-breadcrumb>`,
       });
 
       const sr = getShadowRoot(page);
@@ -230,7 +263,24 @@ describe('bds-breadcrumb', () => {
       expect(nav!.getAttribute('aria-label')).toBe('breadcrumb');
     });
 
-    it('should set aria-current="page" on last item', async () => {
+    it('should set aria-current on the final breadcrumb link instead of the wrapper', async () => {
+      const items = [
+        { label: 'Home', href: '/' },
+        { label: 'Current', href: '/current' }
+      ];
+      const page = await newSpecPage({
+        components: [Breadcrumb],
+        html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
+      });
+      
+      const sr = getShadowRoot(page);
+      expect(sr.querySelector('.breadcrumb__item[aria-current]')).toBeNull();
+      const currentLink = sr.querySelector('a.breadcrumb__link[aria-current="page"]');
+      expect(currentLink).toBeTruthy();
+      expect(currentLink?.getAttribute('href')).toBe('/current');
+    });
+
+    it('should set aria-current on final breadcrumb text when item has no href', async () => {
       const items = [
         { label: 'Home', href: '/' },
         { label: 'Current' }
@@ -239,11 +289,32 @@ describe('bds-breadcrumb', () => {
         components: [Breadcrumb],
         html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
       });
-      
-      // Check for elements with aria-current
+
       const sr = getShadowRoot(page);
-      const elementsWithAriaCurrent = sr.querySelectorAll('[aria-current]');
-      expect(elementsWithAriaCurrent.length).toBeGreaterThan(0);
+      expect(sr.querySelector('.breadcrumb__item[aria-current]')).toBeNull();
+      expect(sr.querySelector('a.breadcrumb__link[aria-current="page"]')).toBeNull();
+
+      const currentText = sr.querySelector('bds-typo.breadcrumb__text[aria-current="page"]');
+      expect(currentText).toBeTruthy();
+      expect(currentText?.textContent?.trim()).toBe('Current');
+    });
+
+    it('should add an accessible label to the dropdown activator button', async () => {
+      const items = [
+        { label: 'Home', href: '/' },
+        { label: 'Level1', href: '/level1' },
+        { label: 'Level2', href: '/level2' },
+        { label: 'Level3', href: '/level3' },
+        { label: 'Current' },
+      ];
+      const page = await newSpecPage({
+        components: [Breadcrumb],
+        html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
+      });
+
+      const sr = getShadowRoot(page);
+      const activator = sr.querySelector('bds-button');
+      expect(activator?.getAttribute('aria-label')).toBe('Mostrar itens ocultos do breadcrumb');
     });
   });
 

--- a/src/components/breadcrumb/test/breadcrumb.spec.ts
+++ b/src/components/breadcrumb/test/breadcrumb.spec.ts
@@ -1,5 +1,13 @@
-import { newSpecPage } from '@stencil/core/testing';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { Breadcrumb } from '../breadcrumb';
+
+function getShadowRoot(page: SpecPage): ShadowRoot {
+  const root = page.root as HTMLElement | undefined;
+  if (!root || !root.shadowRoot) {
+    throw new Error('SpecPage root or shadowRoot missing');
+  }
+  return root.shadowRoot as ShadowRoot;
+}
 
 describe('bds-breadcrumb', () => {
   describe('Component Creation', () => {
@@ -17,8 +25,9 @@ describe('bds-breadcrumb', () => {
         components: [Breadcrumb],
         html: `<bds-breadcrumb></bds-breadcrumb>`,
       });
-      expect(page.root.shadowRoot.querySelector('p')).toBeTruthy();
-      expect(page.root.shadowRoot.textContent).toContain('Sem itens para exibir no Breadcrumb.');
+      const sr = getShadowRoot(page);
+      expect(sr.querySelector('p')).toBeTruthy();
+      expect(sr.textContent).toContain('Sem itens para exibir no Breadcrumb.');
     });
   });
 
@@ -29,7 +38,8 @@ describe('bds-breadcrumb', () => {
         html: `<bds-breadcrumb items="[]"></bds-breadcrumb>`,
       });
       expect(page.rootInstance.parsedItems).toEqual([]);
-      expect(page.root.shadowRoot.textContent).toContain('Sem itens para exibir no Breadcrumb.');
+      const sr = getShadowRoot(page);
+      expect(sr.textContent).toContain('Sem itens para exibir no Breadcrumb.');
     });
 
     it('should handle items prop as JSON string', async () => {
@@ -109,9 +119,10 @@ describe('bds-breadcrumb', () => {
         html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
       });
       
-      const nav = page.root.shadowRoot.querySelector('nav');
+      const sr = getShadowRoot(page);
+      const nav = sr.querySelector('nav');
       expect(nav).toBeTruthy();
-      expect(nav.getAttribute('aria-label')).toBe('breadcrumb');
+      expect(nav?.getAttribute('aria-label')).toBe('breadcrumb');
     });
 
     it('should render simple breadcrumb with 3 items', async () => {
@@ -126,7 +137,8 @@ describe('bds-breadcrumb', () => {
       });
       
       expect(page.rootInstance.parsedItems).toEqual(items);
-      const nav = page.root.shadowRoot.querySelector('nav');
+      const sr = getShadowRoot(page);
+      const nav = sr.querySelector('nav');
       expect(nav).toBeTruthy();
     });
 
@@ -145,8 +157,47 @@ describe('bds-breadcrumb', () => {
       
       expect(page.rootInstance.parsedItems).toEqual(items);
       // Should show: Home ... Current (3 visible items)
-      const nav = page.root.shadowRoot.querySelector('nav');
+      const sr = getShadowRoot(page);
+      const nav = sr.querySelector('nav');
       expect(nav).toBeTruthy();
+    });
+
+    it('collapses items when wrap-items is present (true)', async () => {
+      const items = [
+        { label: 'Home', href: '/' },
+        { label: 'About', href: '/about' },
+        { label: 'Contact', href: '/contact' },
+        { label: 'Current Page' },
+      ];
+      const page = await newSpecPage({
+        components: [Breadcrumb],
+        html: `<bds-breadcrumb items='${JSON.stringify(items)}' wrap-items="true"></bds-breadcrumb>`,
+      });
+
+      const sr = getShadowRoot(page);
+      const breadcrumbItems = sr.querySelectorAll('.breadcrumb__item');
+      expect(breadcrumbItems.length).toBe(3);
+
+      // The collapsed item is represented by a dropdown activator (icon button), not literal '...'
+      expect(sr.querySelector('bds-dropdown')).toBeTruthy();
+    });
+
+    it('shows all items when wrap-items is false', async () => {
+      const items = [
+        { label: 'Home', href: '/' },
+        { label: 'About', href: '/about' },
+        { label: 'Contact', href: '/contact' },
+        { label: 'Current Page' },
+      ];
+      const page = await newSpecPage({
+        components: [Breadcrumb],
+        html: `<bds-breadcrumb items='${JSON.stringify(items)}' wrap-items="false"></bds-breadcrumb>`,
+      });
+
+      const sr = getShadowRoot(page);
+      const breadcrumbItems = sr.querySelectorAll('.breadcrumb__item');
+      expect(breadcrumbItems.length).toBe(4);
+      expect(sr.querySelector('bds-dropdown')).toBeNull();
     });
 
     it('should handle items without href (span elements)', async () => {
@@ -160,7 +211,8 @@ describe('bds-breadcrumb', () => {
       });
       
       expect(page.rootInstance.parsedItems).toEqual(items);
-      const nav = page.root.shadowRoot.querySelector('nav');
+      const sr = getShadowRoot(page);
+      const nav = sr.querySelector('nav');
       expect(nav).toBeTruthy();
     });
   });
@@ -173,8 +225,9 @@ describe('bds-breadcrumb', () => {
         html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
       });
       
-      const nav = page.root.shadowRoot.querySelector('nav');
-      expect(nav.getAttribute('aria-label')).toBe('breadcrumb');
+      const sr = getShadowRoot(page);
+      const nav = sr!.querySelector('nav');
+      expect(nav!.getAttribute('aria-label')).toBe('breadcrumb');
     });
 
     it('should set aria-current="page" on last item', async () => {
@@ -188,7 +241,8 @@ describe('bds-breadcrumb', () => {
       });
       
       // Check for elements with aria-current
-      const elementsWithAriaCurrent = page.root.shadowRoot.querySelectorAll('[aria-current]');
+      const sr = getShadowRoot(page);
+      const elementsWithAriaCurrent = sr.querySelectorAll('[aria-current]');
       expect(elementsWithAriaCurrent.length).toBeGreaterThan(0);
     });
   });
@@ -201,7 +255,8 @@ describe('bds-breadcrumb', () => {
         html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
       });
       
-      const itemElements = page.root.shadowRoot.querySelectorAll('.breadcrumb__item');
+      const sr = getShadowRoot(page);
+      const itemElements = sr.querySelectorAll('.breadcrumb__item');
       expect(itemElements.length).toBeGreaterThan(0);
     });
 
@@ -215,7 +270,8 @@ describe('bds-breadcrumb', () => {
         html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
       });
       
-      const activeElements = page.root.shadowRoot.querySelectorAll('.breadcrumb__item--active');
+      const sr = getShadowRoot(page);
+      const activeElements = sr.querySelectorAll('.breadcrumb__item--active');
       expect(activeElements.length).toBeGreaterThan(0);
     });
   });
@@ -248,7 +304,8 @@ describe('bds-breadcrumb', () => {
       });
       
       // Should contain dropdown for middle items
-      const dropdown = page.root.shadowRoot.querySelector('bds-dropdown');
+      const sr = getShadowRoot(page);
+      const dropdown = sr.querySelector('bds-dropdown');
       expect(dropdown).toBeTruthy();
     });
   });
@@ -264,7 +321,8 @@ describe('bds-breadcrumb', () => {
         html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
       });
       
-      const links = page.root.shadowRoot.querySelectorAll('a.breadcrumb__link');
+      const sr = getShadowRoot(page);
+      const links = sr.querySelectorAll('a.breadcrumb__link');
       expect(links.length).toBeGreaterThan(0);
     });
 
@@ -292,7 +350,8 @@ describe('bds-breadcrumb', () => {
       });
       
       expect(page.rootInstance.parsedItems).toEqual(items);
-      const nav = page.root.shadowRoot.querySelector('nav');
+      const sr = getShadowRoot(page);
+      const nav = sr.querySelector('nav');
       expect(nav).toBeTruthy();
     });
 

--- a/src/components/breadcrumb/test/breadcrumb.spec.ts
+++ b/src/components/breadcrumb/test/breadcrumb.spec.ts
@@ -308,6 +308,33 @@ describe('bds-breadcrumb', () => {
       const dropdown = sr.querySelector('bds-dropdown');
       expect(dropdown).toBeTruthy();
     });
+
+    it('should bind dropdown open state correctly', async () => {
+      const items = [
+        { label: 'Home', href: '/' },
+        { label: 'Level1', href: '/level1' },
+        { label: 'Level2', href: '/level2' },
+        { label: 'Level3', href: '/level3' },
+        { label: 'Current' }
+      ];
+      const page = await newSpecPage({
+        components: [Breadcrumb],
+        html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
+      });
+      
+      // Initial state: dropdown should be closed
+      expect(page.rootInstance.isDropdownOpen).toBe(false);
+      
+      // Toggle dropdown open
+      page.rootInstance.toggleDropdown();
+      await page.waitForChanges();
+      expect(page.rootInstance.isDropdownOpen).toBe(true);
+      
+      // Toggle dropdown closed
+      page.rootInstance.toggleDropdown();
+      await page.waitForChanges();
+      expect(page.rootInstance.isDropdownOpen).toBe(false);
+    });
   });
 
   describe('Link Rendering', () => {

--- a/src/components/breadcrumb/test/breadcrumb.spec.ts
+++ b/src/components/breadcrumb/test/breadcrumb.spec.ts
@@ -277,16 +277,29 @@ describe('bds-breadcrumb', () => {
   });
 
   describe('Dropdown Functionality', () => {
-    it('should toggle dropdown state', async () => {
+    it('should update dropdown state from bdsToggle event', async () => {
+      const items = [
+        { label: 'Home', href: '/' },
+        { label: 'Level1', href: '/level1' },
+        { label: 'Level2', href: '/level2' },
+        { label: 'Level3', href: '/level3' },
+        { label: 'Current' }
+      ];
       const page = await newSpecPage({
         components: [Breadcrumb],
-        html: `<bds-breadcrumb></bds-breadcrumb>`,
+        html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
       });
-      
+
+      const sr = getShadowRoot(page);
+      const dropdown = sr.querySelector('bds-dropdown') as HTMLElement;
       expect(page.rootInstance.isDropdownOpen).toBe(false);
-      page.rootInstance.toggleDropdown();
+
+      dropdown.dispatchEvent(new CustomEvent('bdsToggle', { detail: { value: true } }));
+      await page.waitForChanges();
       expect(page.rootInstance.isDropdownOpen).toBe(true);
-      page.rootInstance.toggleDropdown();
+
+      dropdown.dispatchEvent(new CustomEvent('bdsToggle', { detail: { value: false } }));
+      await page.waitForChanges();
       expect(page.rootInstance.isDropdownOpen).toBe(false);
     });
 
@@ -321,19 +334,22 @@ describe('bds-breadcrumb', () => {
         components: [Breadcrumb],
         html: `<bds-breadcrumb items='${JSON.stringify(items)}'></bds-breadcrumb>`,
       });
-      
-      // Initial state: dropdown should be closed
+
+      const sr = getShadowRoot(page);
+      const dropdown = sr.querySelector('bds-dropdown') as HTMLElement;
+
       expect(page.rootInstance.isDropdownOpen).toBe(false);
-      
-      // Toggle dropdown open
-      page.rootInstance.toggleDropdown();
+      expect(dropdown.hasAttribute('open')).toBe(false);
+
+      dropdown.dispatchEvent(new CustomEvent('bdsToggle', { detail: { value: true } }));
       await page.waitForChanges();
       expect(page.rootInstance.isDropdownOpen).toBe(true);
-      
-      // Toggle dropdown closed
-      page.rootInstance.toggleDropdown();
+      expect(dropdown.hasAttribute('open')).toBe(true);
+
+      dropdown.dispatchEvent(new CustomEvent('bdsToggle', { detail: { value: false } }));
       await page.waitForChanges();
       expect(page.rootInstance.isDropdownOpen).toBe(false);
+      expect(dropdown.hasAttribute('open')).toBe(false);
     });
   });
 

--- a/src/components/grid/grid.stories.jsx
+++ b/src/components/grid/grid.stories.jsx
@@ -709,7 +709,7 @@ const text = {
 };
 
 export const examplePageGrid = () => (
-  <bds-grid xxs="11">
+  <bds-grid xxs="12">
 
     <bds-grid xxs="12" direction="column" wrap="no-wrap" style={page}>
 


### PR DESCRIPTION
This pull request introduces significant improvements to the `bds-breadcrumb` component, focusing on enhanced configurability, accessibility, and maintainability. The main addition is a new `wrapItems` property, which allows developers to control whether breadcrumb items collapse into a dropdown when too many are present. The update also brings improved Storybook stories, new and updated tests, and refined styles for better user experience.

**Component Functionality Enhancements:**

- Added a `wrapItems` property (as both prop and attribute) to `bds-breadcrumb`, enabling control over whether breadcrumb items collapse into a dropdown when there are more than three items. The logic robustly normalizes boolean/string values and prioritizes the attribute over the prop for initial value. [[1]](diffhunk://#diff-59aaf308ae08315bc5be429731d27dde77c2d2fab9faaec6490aebaf730ffa96L1-R28) [[2]](diffhunk://#diff-59aaf308ae08315bc5be429731d27dde77c2d2fab9faaec6490aebaf730ffa96R48-R62) [[3]](diffhunk://#diff-59aaf308ae08315bc5be429731d27dde77c2d2fab9faaec6490aebaf730ffa96L42-R93)
- Refactored rendering logic to use the new `wrapItems` property, so developers can choose between showing all items or collapsing middle items into a dropdown. [[1]](diffhunk://#diff-59aaf308ae08315bc5be429731d27dde77c2d2fab9faaec6490aebaf730ffa96L42-R93) [[2]](diffhunk://#diff-59aaf308ae08315bc5be429731d27dde77c2d2fab9faaec6490aebaf730ffa96L103-R179)

**Storybook & Documentation Improvements:**

- Updated Storybook stories to support and demonstrate the new `wrapItems` property, including proper prop binding and controls. [[1]](diffhunk://#diff-3f84e4587be99ccd6afe658d3799630ae110d3614a9582f84d87d3a2fbe5b5a8L16-R26) [[2]](diffhunk://#diff-3f84e4587be99ccd6afe658d3799630ae110d3614a9582f84d87d3a2fbe5b5a8R37-R51) [[3]](diffhunk://#diff-3f84e4587be99ccd6afe658d3799630ae110d3614a9582f84d87d3a2fbe5b5a8R74) [[4]](diffhunk://#diff-3f84e4587be99ccd6afe658d3799630ae110d3614a9582f84d87d3a2fbe5b5a8R102)
- Extended the component’s documentation (`readme.md`) to document the new `wrapItems` property and correct the dependencies/graph.

**Testing Enhancements:**

- Expanded and improved unit tests to cover the new `wrapItems` logic, including tests for both collapsed and expanded modes, and dropdown open state. Added a helper for accessing the shadow DOM in tests. [[1]](diffhunk://#diff-67a4a1d46cfbcf2462d3b0687144074bd3b42af1cf4479d83d1eb9608e90ca46L1-R11) [[2]](diffhunk://#diff-67a4a1d46cfbcf2462d3b0687144074bd3b42af1cf4479d83d1eb9608e90ca46L148-R202) [[3]](diffhunk://#diff-67a4a1d46cfbcf2462d3b0687144074bd3b42af1cf4479d83d1eb9608e90ca46L251-R337)

**Styling Updates:**

- Improved breadcrumb item styling, including transitions, hover effects, and active item appearance for better accessibility and user experience.

**Minor Fixes:**

- Fixed minor issues in sample data and improved test robustness (e.g., handling of the `Current Page` item in stories).

These changes make the breadcrumb component more flexible, robust, and user-friendly, while also improving code quality and test coverage.

Related work item [AB#1033048](https://curupira.visualstudio.com/6cd5c1b3-c813-4ff6-b562-e74fb11ea8c2/_workitems/edit/1033048) 