### PR TITLE
feat(input-chips): expose chip styling hooks

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1339,6 +1339,10 @@ export namespace Components {
          */
         "blurCreation": boolean;
         /**
+          * When true, removes the border from the input component.
+         */
+        "borderless"?: boolean;
+        /**
           * The chips on the component Should be passed this way: chips='["chip1", "chip2"]'
          */
         "chips": string[] | string;
@@ -5241,6 +5245,10 @@ declare namespace LocalJSX {
           * When true, the press enter will be simulated on blur event.
          */
         "blurCreation"?: boolean;
+        /**
+          * When true, removes the border from the input component.
+         */
+        "borderless"?: boolean;
         /**
           * The chips on the component Should be passed this way: chips='["chip1", "chip2"]'
          */

--- a/src/components/chip-clickable/chip-clickable.mdx
+++ b/src/components/chip-clickable/chip-clickable.mdx
@@ -45,6 +45,29 @@ Alguns exemplos de Eventos do Chip Clickable.
 
 <Source of={ChipClickableStories.Events} />
 <br></br>
+
+## CSS Custom Properties
+
+O componente expõe as seguintes propriedades CSS customizáveis para permitir que componentes pai (como `bds-input-chips`) estilizem seus chips filhos:
+
+| Propriedade CSS | Descrição | Valor padrão |
+| --- | --- | --- |
+| `--bds-chip-text-color` | Controla a cor do texto e ícones do chip | `inherit` |
+| `--bds-chip-icon-color` | Controla a cor específica dos ícones | `inherit` |
+| `--bds-chip-border` | Controla o estilo da borda no modo outline | `1px solid var(--color-border-1)` |
+
+Essas propriedades permitem que componentes pai customize a aparência dos chips sem quebrar o encapsulamento do Shadow DOM. Exemplo de uso:
+
+```css
+bds-chip-clickable {
+  --bds-chip-text-color: #fff;
+  --bds-chip-icon-color: #fff;
+  --bds-chip-border: 2px solid #007bff;
+}
+```
+
+<br></br>
+
 ## Usando em React
 
 <Source of={ChipClickableStories.FrameworkReact} />

--- a/src/components/chip-clickable/chip-clickable.mdx
+++ b/src/components/chip-clickable/chip-clickable.mdx
@@ -52,11 +52,11 @@ O componente expõe as seguintes propriedades CSS customizáveis para permitir q
 
 | Propriedade CSS | Descrição | Valor padrão |
 | --- | --- | --- |
-| `--bds-chip-text-color` | Controla a cor do texto e ícones do chip | `inherit` |
+| `--bds-chip-text-color` | Controla a cor do texto do chip | `inherit` |
 | `--bds-chip-icon-color` | Controla a cor específica dos ícones | `inherit` |
-| `--bds-chip-border` | Controla o estilo da borda no modo outline | `1px solid var(--color-border-1)` |
+| `--bds-chip-border` | Controla o estilo da borda no modo outline | `1px solid rgba(0, 0, 0, 0.2)` |
 
-Essas propriedades permitem que componentes pai customize a aparência dos chips sem quebrar o encapsulamento do Shadow DOM. Exemplo de uso:
+Essas propriedades permitem que componentes pai personalizem a aparência dos chips sem quebrar o encapsulamento do Shadow DOM. Exemplo de uso:
 
 ```css
 bds-chip-clickable {

--- a/src/components/chip-clickable/chip-clickable.scss
+++ b/src/components/chip-clickable/chip-clickable.scss
@@ -94,6 +94,7 @@
       z-index: 2;
       font-family: $font-family;
       line-height: 1;
+      color: var(--bds-chip-text-color, inherit);
     }
     &--icon {
       display: flex;
@@ -101,6 +102,7 @@
       height: 16px;
       padding-right: 2px;
       z-index: 2;
+      color: var(--bds-chip-icon-color, inherit);
     }
     &--close {
       display: flex;
@@ -112,6 +114,7 @@
       z-index: 2;
       position: relative;
       cursor: pointer;
+      color: var(--bds-chip-icon-color, inherit);
 
       .close_focus:focus {
         position: absolute;
@@ -161,7 +164,7 @@
       color: $color-content-din;
     }
     &--outline {
-      border: 1px solid $color-border-1;
+      border: var(--bds-chip-border, 1px solid #{$color-border-1});
       color: $color-content-default;
     }
     &:focus-visible {

--- a/src/components/chip-clickable/chip-clickable.tsx
+++ b/src/components/chip-clickable/chip-clickable.tsx
@@ -107,6 +107,7 @@ export class ChipClickable {
           }}
           onClick={this.handleClick.bind(this)}
           data-test={this.dataTest}
+          part="chip"
         >
           {this.clickable && !this.disabled && (
             <div class="chip_focus" onKeyDown={this.handleClickKey.bind(this)} tabindex="0"></div>

--- a/src/components/chip-clickable/readme.md
+++ b/src/components/chip-clickable/readme.md
@@ -28,6 +28,13 @@
 | `chipClickableClose` | Triggered after a mouse click on close icon, return id element. Only fired when close is true. | `CustomEvent<any>` |
 
 
+## Shadow Parts
+
+| Part     | Description |
+| -------- | ----------- |
+| `"chip"` | The internal chip container, including its surface and outline styles. |
+
+
 ## Dependencies
 
 ### Used by

--- a/src/components/chip-clickable/test/chip-clickable.spec.ts
+++ b/src/components/chip-clickable/test/chip-clickable.spec.ts
@@ -16,6 +16,12 @@ describe('bds-chip-clickable', () => {
     expect(page.root.shadowRoot.querySelector('.chip_clickable')).toBeTruthy();
   });
 
+  it('should expose the visual chip container as a shadow part', async () => {
+    const chipElement = page.root.shadowRoot.querySelector('.chip_clickable');
+
+    expect(chipElement.getAttribute('part')).toBe('chip');
+  });
+
   it('should render with default props', async () => {
     expect(page.rootInstance.color).toBe('default');
     expect(page.rootInstance.size).toBe('standard');

--- a/src/components/input-chips/input-chips.scss
+++ b/src/components/input-chips/input-chips.scss
@@ -247,6 +247,20 @@ $input_fixed: 140px;
     padding: $input-padding-label;
   }
 
+  &--borderless {
+    border: none !important;
+    box-shadow: none !important;
+
+    &:hover {
+      border: none !important;
+    }
+
+    &.input--pressed {
+      border: none !important;
+      box-shadow: none !important;
+    }
+  }
+
   &__icon {
     cursor: inherit;
     display: flex;

--- a/src/components/input-chips/input-chips.scss
+++ b/src/components/input-chips/input-chips.scss
@@ -249,7 +249,6 @@ $input_fixed: 140px;
 
   &--borderless {
     border: none !important;
-    box-shadow: none !important;
 
     &:hover {
       border: none !important;
@@ -257,7 +256,6 @@ $input_fixed: 140px;
 
     &.input--pressed {
       border: none !important;
-      box-shadow: none !important;
     }
   }
 

--- a/src/components/input-chips/input-chips.scss
+++ b/src/components/input-chips/input-chips.scss
@@ -248,14 +248,14 @@ $input_fixed: 140px;
   }
 
   &--borderless {
-    border: none !important;
+    border: none;
 
     &:hover {
-      border: none !important;
+      border: none;
     }
 
     &.input--pressed {
-      border: none !important;
+      border: none;
     }
   }
 

--- a/src/components/input-chips/input-chips.stories.jsx
+++ b/src/components/input-chips/input-chips.stories.jsx
@@ -22,6 +22,7 @@ export const Properties = (args) => {
         blur-creation={args.blurCreation}
         disable-submit={args.disableSubmit}
         disabled={args.disabled}
+        borderless={args.borderless}
       ></bds-input-chips>
     </bds-grid>
   );
@@ -36,6 +37,7 @@ Properties.args = {
   blurCreation: false,
   disableSubmit: false,
   disabled: false,
+  borderless: false,
 };
 
 Properties.argTypes = {
@@ -90,6 +92,13 @@ Properties.argTypes = {
     control: 'boolean',
   },
   disabled: {
+    table: {
+      defaultValue: { summary: 'false' },
+    },
+
+    control: 'boolean',
+  },
+  borderless: {
     table: {
       defaultValue: { summary: 'false' },
     },
@@ -190,24 +199,20 @@ export const FrameworkReact = () => {
 export const StyledChips = () => {
   const styles = `
     bds-input-chips::part(chip) {
-      background-color: #1976D2;
-      border-color: #1976D2;
-      border-radius: 16px;
-      color: #ffffff;
-      font-weight: 600;
+      background-color: #1976D2 !important;
+      border-color: #1976D2 !important;
+      border-radius: 16px !important;
+      color: #ffffff !important;
+      font-weight: 600 !important;
     }
 
     bds-input-chips::part(chip):hover {
-      background-color: #1565C0;
-      border-color: #1565C0;
+      background-color: #1565C0 !important;
+      border-color: #1565C0 !important;
     }
 
     /* Apply color to text and delete icon inside the chip */
-    bds-input-chips::part(chip) bds-typo {
-      color: #ffffff !important;
-    }
-
-    bds-input-chips::part(chip) bds-icon {
+    bds-input-chips::part(chip) * {
       color: #ffffff !important;
     }
   `;

--- a/src/components/input-chips/input-chips.stories.jsx
+++ b/src/components/input-chips/input-chips.stories.jsx
@@ -187,3 +187,37 @@ export const Methods = () => {
 export const FrameworkReact = () => {
   return <BdsInputChips id="input-chips" label="input chips" chips='["chip1", "chip2"]'></BdsInputChips>;
 };
+export const StyledChips = () => {
+  const styles = `
+    bds-input-chips::part(chip) {
+      background-color: #1976D2;
+      border-color: #1976D2;
+      color: #ffffff;
+      font-weight: 600;
+    }
+
+    bds-input-chips::part(chip):hover {
+      background-color: #1565C0;
+      border-color: #1565C0;
+    }
+  `;
+
+  return (
+    <>
+      <style>{styles}</style>
+      <bds-grid direction="column" gap="2">
+        <bds-typo variant="fs-16" bold="semi-bold">
+          Chips with Custom Styling
+        </bds-typo>
+        <bds-typo variant="fs-12">
+          This example demonstrates how to style chips using the ::part(chip) CSS selector
+        </bds-typo>
+        <bds-input-chips 
+          label="Add custom styled chips" 
+          chips='{"Primary", "Styled", "Chips"}'
+          placeholder="Type and press Enter"
+        ></bds-input-chips>
+      </bds-grid>
+    </>
+  );
+};

--- a/src/components/input-chips/input-chips.stories.jsx
+++ b/src/components/input-chips/input-chips.stories.jsx
@@ -198,19 +198,22 @@ export const FrameworkReact = () => {
 };
 export const StyledChips = () => {
   const styles = `
+    /* Note: ::part(chip) can style the chip container element itself and pseudo-classes like :hover,
+     * but cannot target internal descendants (bds-typo, bds-icon) across the shadow DOM.
+     * For text/icon color, use CSS custom properties (--bds-chip-text-color, --bds-chip-icon-color)
+     * exported by the chip-clickable component. */
     bds-input-chips::part(chip) {
       background-color: #1976D2 !important;
-      border-color: #1976D2 !important;
       border-radius: 16px !important;
-      color: #ffffff !important;
-      font-weight: 600 !important;
     }
 
     bds-input-chips::part(chip):hover {
       background-color: #1565C0 !important;
-      border-color: #1565C0 !important;
     }
-`;
+    
+    bds-input-chips {
+      --bds-chip-text-color: #ffffff;
+      --bds-chip-icon-color: #ffffff;
 
   return (
     <>

--- a/src/components/input-chips/input-chips.stories.jsx
+++ b/src/components/input-chips/input-chips.stories.jsx
@@ -236,3 +236,170 @@ export const StyledChips = () => {
     </>
   );
 };
+
+export const StyledChipsWithCustomColors = () => {
+  const styles = `
+    /* Option 2: Override text color when needed */
+    .blue-chips bds-input-chips {
+      --bds-chip-text-color: #ffffff;
+      --bds-chip-icon-color: #ffffff;
+    }
+
+    .blue-chips bds-input-chips::part(chip) {
+      background-color: #1976D2;
+      border-radius: 16px;
+    }
+
+    .green-chips bds-input-chips {
+      --bds-chip-text-color: #ffffff;
+      --bds-chip-icon-color: #ffffff;
+    }
+
+    .green-chips bds-input-chips::part(chip) {
+      background-color: #059669;
+      border-radius: 16px;
+    }
+
+    .orange-chips bds-input-chips {
+      --bds-chip-text-color: #000000;
+      --bds-chip-icon-color: #000000;
+    }
+
+    .orange-chips bds-input-chips::part(chip) {
+      background-color: #D97706;
+      border-radius: 16px;
+    }
+  `;
+
+  return (
+    <>
+      <style>{styles}</style>
+      <bds-grid direction="column" gap="2">
+        <bds-typo variant="fs-16" bold="semi-bold">
+          Chips with Custom Colors - Override per Group
+        </bds-typo>
+        <bds-typo variant="fs-12">
+          Each chip group can have its own text and background colors via custom properties.
+        </bds-typo>
+        
+        <div className="blue-chips">
+          <bds-typo variant="fs-12" bold="semi-bold">Blue Chips (White text)</bds-typo>
+          <bds-input-chips 
+            label="Blue chips" 
+            chips='["Feature", "Active"]'
+            placeholder="Type and press Enter"
+          ></bds-input-chips>
+        </div>
+
+        <div className="green-chips">
+          <bds-typo variant="fs-12" bold="semi-bold">Green Chips (White text)</bds-typo>
+          <bds-input-chips 
+            label="Green chips" 
+            chips='["Success", "Complete"]'
+            placeholder="Type and press Enter"
+          ></bds-input-chips>
+        </div>
+
+        <div className="orange-chips">
+          <bds-typo variant="fs-12" bold="semi-bold">Orange Chips (Black text)</bds-typo>
+          <bds-input-chips 
+            label="Orange chips" 
+            chips='["Warning", "Attention"]'
+            placeholder="Type and press Enter"
+          ></bds-input-chips>
+        </div>
+      </bds-grid>
+    </>
+  );
+};
+
+export const OutlinedChipStyle = () => {
+  const styles = `
+    bds-input-chips {
+      --bds-chip-text-color: #1E6BF1;
+      --bds-chip-icon-color: #1E6BF1;
+      --bds-chip-border: 1.5px solid #1E6BF1;
+    }
+
+    bds-input-chips::part(chip) {
+      background-color: #1E6BF118;
+      border-radius: 16px;
+    }
+
+    bds-input-chips::part(chip):hover {
+      background-color: #1E6BF128;
+    }
+  `;
+
+  return (
+    <>
+      <style>{styles}</style>
+      <bds-grid direction="column" gap="2">
+        <bds-typo variant="fs-16" bold="semi-bold">
+          Outlined Chip Style
+        </bds-typo>
+        <bds-typo variant="fs-12">
+          Border-based styling with light background fill using custom properties
+        </bds-typo>
+        <bds-input-chips 
+          label="Add outlined chips" 
+          chips='["Design", "System", "Component"]'
+          placeholder="Type and press Enter"
+        ></bds-input-chips>
+      </bds-grid>
+    </>
+  );
+};
+
+export const OutlineChipVariant = () => {
+  const styles = `
+    /* Option 1: Use CSS custom property (recommended) - no !important needed */
+    .no-border-custom-prop bds-input-chips {
+      --bds-chip-border: none;
+      --bds-chip-text-color: #282828;
+      --bds-chip-icon-color: #282828;
+    }
+
+    /* Option 2: Override using ::part() with !important (works but less clean) */
+    .no-border-override bds-input-chips::part(chip) {
+      border: none !important;
+    }
+
+    .no-border-override bds-input-chips {
+      --bds-chip-text-color: #282828;
+      --bds-chip-icon-color: #282828;
+    }
+  `;
+
+  return (
+    <>
+      <style>{styles}</style>
+      <bds-grid direction="column" gap="2">
+        <bds-typo variant="fs-16" bold="semi-bold">
+          Outline Chip Variant - Remove Border
+        </bds-typo>
+        <bds-typo variant="fs-12">
+          Two approaches: using CSS custom property (recommended) or ::part() override
+        </bds-typo>
+
+        <bds-typo variant="fs-13" bold="semi-bold">Option 1: Custom Property (Recommended)</bds-typo>
+        <div className="no-border-custom-prop">
+          <bds-input-chips 
+            label="Borderless via custom property" 
+            chips='["Tag", "Label", "Category"]'
+            placeholder="Type and press Enter"
+          ></bds-input-chips>
+        </div>
+
+        <bds-typo variant="fs-13" bold="semi-bold">Option 2: ::part() Override</bds-typo>
+        <div className="no-border-override">
+          <bds-input-chips 
+            label="Borderless via ::part()" 
+            chips='["Tag", "Label", "Category"]'
+            placeholder="Type and press Enter"
+          ></bds-input-chips>
+        </div>
+      </bds-grid>
+    </>
+  );
+};

--- a/src/components/input-chips/input-chips.stories.jsx
+++ b/src/components/input-chips/input-chips.stories.jsx
@@ -210,12 +210,7 @@ export const StyledChips = () => {
       background-color: #1565C0 !important;
       border-color: #1565C0 !important;
     }
-
-    /* Apply color to text and delete icon inside the chip */
-    bds-input-chips::part(chip) * {
-      color: #ffffff !important;
-    }
-  `;
+`;
 
   return (
     <>
@@ -229,7 +224,7 @@ export const StyledChips = () => {
         </bds-typo>
         <bds-input-chips 
           label="Add custom styled chips" 
-          chips='{"Primary", "Styled", "Chips"}'
+          chips='["Primary", "Styled", "Chips"]'
           placeholder="Type and press Enter"
         ></bds-input-chips>
       </bds-grid>

--- a/src/components/input-chips/input-chips.stories.jsx
+++ b/src/components/input-chips/input-chips.stories.jsx
@@ -192,6 +192,7 @@ export const StyledChips = () => {
     bds-input-chips::part(chip) {
       background-color: #1976D2;
       border-color: #1976D2;
+      border-radius: 16px;
       color: #ffffff;
       font-weight: 600;
     }
@@ -199,6 +200,15 @@ export const StyledChips = () => {
     bds-input-chips::part(chip):hover {
       background-color: #1565C0;
       border-color: #1565C0;
+    }
+
+    /* Apply color to text and delete icon inside the chip */
+    bds-input-chips::part(chip) bds-typo {
+      color: #ffffff !important;
+    }
+
+    bds-input-chips::part(chip) bds-icon {
+      color: #ffffff !important;
     }
   `;
 

--- a/src/components/input-chips/input-chips.stories.jsx
+++ b/src/components/input-chips/input-chips.stories.jsx
@@ -214,6 +214,8 @@ export const StyledChips = () => {
     bds-input-chips {
       --bds-chip-text-color: #ffffff;
       --bds-chip-icon-color: #ffffff;
+    }
+  `;
 
   return (
     <>

--- a/src/components/input-chips/input-chips.tsx
+++ b/src/components/input-chips/input-chips.tsx
@@ -148,6 +148,10 @@ export class InputChips {
    */
   @Prop() dtButtonClose?: string = null;
   /**
+   * When true, removes the border from the input component.
+   */
+  @Prop() borderless?: boolean = false;
+  /**
    * Emitted when the chip has added.
    */
   @Event() bdsChange!: EventEmitter;
@@ -562,6 +566,7 @@ export class InputChips {
             'input--state-disabled': this.disabled,
             'input--label': !!this.label,
             'input--pressed': isPressed,
+            'input--borderless': this.borderless,
           }}
           onClick={this.onClickWrapper}
           onKeyDown={this.keyPressWrapper}

--- a/src/components/input-chips/input-chips.tsx
+++ b/src/components/input-chips/input-chips.tsx
@@ -460,6 +460,7 @@ export class InputChips {
             close={!this.disabled}
             onChipClickableClose={(event) => this.removeChip(event)}
             dtButtonClose={this.dtButtonClose}
+            part="chip"
           >
             {chip}
           </bds-chip-clickable>
@@ -474,6 +475,7 @@ export class InputChips {
               close={!this.disabled}
               onChipClickableClose={(event) => this.removeChip(event)}
               dtButtonClose={this.dtButtonClose}
+              part="chip"
             >
               {`${chip.slice(0, limit)}...`}
             </bds-chip-clickable>

--- a/src/components/input-chips/input-chips.tsx
+++ b/src/components/input-chips/input-chips.tsx
@@ -464,14 +464,14 @@ export class InputChips {
             close={!this.disabled}
             onChipClickableClose={(event) => this.removeChip(event)}
             dtButtonClose={this.dtButtonClose}
-            part="chip"
+            exportparts="chip"
           >
             {chip}
           </bds-chip-clickable>
         );
       } else {
         return (
-          <bds-tooltip key={id} position="top-center" tooltip-text={chip}>
+          <bds-tooltip key={id} position="top-center" tooltip-text={chip} exportparts="chip">
             <bds-chip-clickable
               id={id}
               key={id}
@@ -479,7 +479,7 @@ export class InputChips {
               close={!this.disabled}
               onChipClickableClose={(event) => this.removeChip(event)}
               dtButtonClose={this.dtButtonClose}
-              part="chip"
+              exportparts="chip"
             >
               {`${chip.slice(0, limit)}...`}
             </bds-chip-clickable>

--- a/src/components/input-chips/readme.md
+++ b/src/components/input-chips/readme.md
@@ -116,9 +116,9 @@ Type: `Promise<void>`
 
 | Part                | Description |
 | ------------------- | ----------- |
-| `"chip"`            |             |
-| `"input-container"` |             |
-| `"input__message"`  |             |
+| `"chip"`            | The `<bds-chip-clickable>` host element that wraps each rendered chip. Can be used to apply global styles to all chips (e.g., `bds-input-chips::part(chip) { ... }`). Note: styling of internal chip elements (text, icon) requires CSS custom properties (--bds-chip-text-color, --bds-chip-icon-color) on the `bds-input-chips` component, as the ::part() pseudo-element cannot target descendants across shadow DOM boundaries. |
+| `"input-container"` | The main input container that holds the chips and text input field. |
+| `"input__message"`  | The feedback message container that displays error, success, or helper text. |
 
 
 ## Dependencies

--- a/src/components/input-chips/readme.md
+++ b/src/components/input-chips/readme.md
@@ -10,6 +10,7 @@
 | Property         | Attribute          | Description                                                                                                             | Type                 | Default     |
 | ---------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- | -------------------- | ----------- |
 | `blurCreation`   | `blur-creation`    | When true, the press enter will be simulated on blur event.                                                             | `boolean`            | `false`     |
+| `borderless`     | `borderless`       | When true, removes the border from the input component.                                                                 | `boolean`            | `false`     |
 | `chips`          | `chips`            | The chips on the component Should be passed this way: chips='["chip1", "chip2"]'                                        | `string \| string[]` | `[]`        |
 | `counterLength`  | `counter-length`   | Passing true to display a counter of available size, it is necessary to pass another maxlength property.                | `boolean`            | `false`     |
 | `danger`         | `danger`           | Add state danger on input, use for use feedback.                                                                        | `boolean`            | `false`     |
@@ -115,6 +116,7 @@ Type: `Promise<void>`
 
 | Part                | Description |
 | ------------------- | ----------- |
+| `"chip"`            |             |
 | `"input-container"` |             |
 | `"input__message"`  |             |
 

--- a/src/components/input-chips/readme.md
+++ b/src/components/input-chips/readme.md
@@ -116,7 +116,7 @@ Type: `Promise<void>`
 
 | Part                | Description |
 | ------------------- | ----------- |
-| `"chip"`            | The `<bds-chip-clickable>` host element that wraps each rendered chip. Can be used to apply global styles to all chips (e.g., `bds-input-chips::part(chip) { ... }`). Note: styling of internal chip elements (text, icon) requires CSS custom properties (--bds-chip-text-color, --bds-chip-icon-color) on the `bds-input-chips` component, as the ::part() pseudo-element cannot target descendants across shadow DOM boundaries. |
+| `"chip"`            | The internal visual container of each `<bds-chip-clickable>`, forwarded through the nested Shadow DOM boundaries. Use `bds-input-chips::part(chip) { ... }` to style the chip surface; use `--bds-chip-text-color` and `--bds-chip-icon-color` on `bds-input-chips` for text and icon colors. |
 | `"input-container"` | The main input container that holds the chips and text input field. |
 | `"input__message"`  | The feedback message container that displays error, success, or helper text. |
 

--- a/src/components/input-chips/test/input-chips.e2e.ts
+++ b/src/components/input-chips/test/input-chips.e2e.ts
@@ -146,4 +146,60 @@ describe('bds-input-chips e2e tests', () => {
       expect(focusedElement).toBe('BDS-INPUT-CHIPS');
     });
   });
+
+  describe('Shadow Parts and Styling', () => {
+    it('should expose part="chip" attribute on rendered chips for external styling', async () => {
+      page = await newE2EPage({
+        html: `<bds-input-chips chips='["tag1", "tag2"]'></bds-input-chips>`,
+      });
+
+      const inputChips = await page.find('bds-input-chips');
+      const chips = await inputChips.findAll('bds-chip-clickable');
+      
+      expect(chips.length).toBe(2);
+      
+      for (const chip of chips) {
+        const part = await chip.getAttribute('part');
+        expect(part).toBe('chip');
+      }
+    });
+
+    it('should apply borderless styling when borderless prop is true', async () => {
+      page = await newE2EPage({
+        html: `<bds-input-chips borderless></bds-input-chips>`,
+      });
+
+      const inputChips = await page.find('bds-input-chips');
+      const inputContainer = await inputChips.find('>>> .input');
+      const borderlessClass = await inputContainer.getAttribute('class');
+      
+      expect(borderlessClass).toContain('input--borderless');
+    });
+
+    it('should maintain focus ring visibility in borderless mode', async () => {
+      page = await newE2EPage({
+        html: `
+          <style>
+            bds-input-chips.test-borderless {
+              --focus-shadow: 0 0 0 2px #0066ff;
+            }
+          </style>
+          <bds-input-chips borderless class="test-borderless"></bds-input-chips>
+        `,
+      });
+
+      const inputElement = await page.find('bds-input-chips >>> input');
+      await inputElement.focus();
+      await page.waitForChanges();
+
+      const computedBoxShadow = await page.evaluate(() => {
+        const input = document.querySelector('bds-input-chips')?.shadowRoot?.querySelector('input');
+        return window.getComputedStyle(input).boxShadow;
+      });
+
+      // The borderless modifier should not remove box-shadow entirely
+      // (the focus ring from state selectors should be preserved)
+      expect(computedBoxShadow).not.toBe('none');
+    });
+  });
 });

--- a/src/components/input-chips/test/input-chips.e2e.ts
+++ b/src/components/input-chips/test/input-chips.e2e.ts
@@ -148,7 +148,7 @@ describe('bds-input-chips e2e tests', () => {
   });
 
   describe('Shadow Parts and Styling', () => {
-    it('should expose part="chip" attribute on rendered chips for external styling', async () => {
+    it('should forward the chip part from rendered chips for external styling', async () => {
       page = await newE2EPage({
         html: `<bds-input-chips chips='["tag1", "tag2"]'></bds-input-chips>`,
       });
@@ -158,9 +158,65 @@ describe('bds-input-chips e2e tests', () => {
       expect(chips.length).toBe(2);
       
       for (const chip of chips) {
-        const part = await chip.getAttribute('part');
-        expect(part).toBe('chip');
+        const exportedParts = await chip.getAttribute('exportparts');
+        expect(exportedParts).toBe('chip');
       }
+    });
+
+    it('should apply external styles to the visual chip container', async () => {
+      page = await newE2EPage({
+        html: `
+          <style>
+            bds-input-chips::part(chip) {
+              background-color: #1976d2;
+              border-radius: 16px;
+            }
+          </style>
+          <bds-input-chips chips='["tag", "a chip value that is longer than twenty characters"]'></bds-input-chips>
+        `,
+      });
+
+      const chipStyles = await page.evaluate(() => {
+        const inputChips = document.querySelector('bds-input-chips');
+        const shortChip = inputChips?.shadowRoot?.querySelector('bds-chip-clickable');
+        const tooltip = inputChips?.shadowRoot?.querySelector('bds-tooltip');
+        const longChip = tooltip?.querySelector('bds-chip-clickable');
+
+        return [shortChip, longChip].map((chip) => {
+          const container = chip?.shadowRoot?.querySelector('.chip_clickable');
+          const styles = container && window.getComputedStyle(container);
+
+          return {
+            backgroundColor: styles?.backgroundColor,
+            borderRadius: styles?.borderRadius,
+          };
+        });
+      });
+
+      expect(chipStyles).toEqual([
+        { backgroundColor: 'rgb(25, 118, 210)', borderRadius: '16px' },
+        { backgroundColor: 'rgb(25, 118, 210)', borderRadius: '16px' },
+      ]);
+    });
+
+    it('should forward the chip part through the tooltip for long chips', async () => {
+      page = await newE2EPage({
+        html: `<bds-input-chips chips='["a chip value that is longer than twenty characters"]'></bds-input-chips>`,
+      });
+
+      const exportedParts = await page.evaluate(() => {
+        const inputChips = document.querySelector('bds-input-chips');
+        const tooltip = inputChips?.shadowRoot?.querySelector('bds-tooltip');
+        const chip = tooltip?.querySelector('bds-chip-clickable');
+
+        return {
+          tooltip: tooltip?.getAttribute('exportparts'),
+          chip: chip?.getAttribute('exportparts'),
+        };
+      });
+
+      expect(exportedParts.tooltip).toBe('chip');
+      expect(exportedParts.chip).toBe('chip');
     });
 
     it('should apply borderless styling when borderless prop is true', async () => {
@@ -176,14 +232,7 @@ describe('bds-input-chips e2e tests', () => {
 
     it('should maintain focus ring visibility in borderless mode', async () => {
       page = await newE2EPage({
-        html: `
-          <style>
-            bds-input-chips.test-borderless {
-              --focus-shadow: 0 0 0 2px #0066ff;
-            }
-          </style>
-          <bds-input-chips borderless class="test-borderless"></bds-input-chips>
-        `,
+        html: `<bds-input-chips borderless></bds-input-chips>`,
       });
 
       const inputElement = await page.find('bds-input-chips >>> input');

--- a/src/components/input-chips/test/input-chips.e2e.ts
+++ b/src/components/input-chips/test/input-chips.e2e.ts
@@ -153,8 +153,7 @@ describe('bds-input-chips e2e tests', () => {
         html: `<bds-input-chips chips='["tag1", "tag2"]'></bds-input-chips>`,
       });
 
-      const inputChips = await page.find('bds-input-chips');
-      const chips = await inputChips.findAll('bds-chip-clickable');
+      const chips = await page.findAll('bds-input-chips >>> bds-chip-clickable');
       
       expect(chips.length).toBe(2);
       
@@ -169,8 +168,7 @@ describe('bds-input-chips e2e tests', () => {
         html: `<bds-input-chips borderless></bds-input-chips>`,
       });
 
-      const inputChips = await page.find('bds-input-chips');
-      const inputContainer = await inputChips.find('>>> .input');
+      const inputContainer = await page.find('bds-input-chips >>> .input');
       const borderlessClass = await inputContainer.getAttribute('class');
       
       expect(borderlessClass).toContain('input--borderless');
@@ -189,13 +187,11 @@ describe('bds-input-chips e2e tests', () => {
       });
 
       const inputElement = await page.find('bds-input-chips >>> input');
+      const inputContainer = await page.find('bds-input-chips >>> .input');
       await inputElement.focus();
       await page.waitForChanges();
 
-      const computedBoxShadow = await page.evaluate(() => {
-        const input = document.querySelector('bds-input-chips')?.shadowRoot?.querySelector('input');
-        return window.getComputedStyle(input).boxShadow;
-      });
+      const computedBoxShadow = await inputContainer.getComputedStyle().then((style) => style.boxShadow);
 
       // The borderless modifier should not remove box-shadow entirely
       // (the focus ring from state selectors should be preserved)

--- a/src/components/input-chips/test/input-chips.spec.ts
+++ b/src/components/input-chips/test/input-chips.spec.ts
@@ -618,4 +618,41 @@ describe('bds-input-chips', () => {
     
     expect(component.internalChips).toEqual(['chip1', 'chip2']);
   });
+
+  // New feature tests for part attribute and borderless prop
+  it('should render chips with part="chip" attribute for external styling', async () => {
+    const page = await newSpecPage({
+      components: [InputChips],
+      html: '<bds-input-chips chips=\'["tag1", "tag2"]\'></bds-input-chips>',
+    });
+
+    await page.waitForChanges();
+    
+    const chips = page.root.shadowRoot.querySelectorAll('bds-chip-clickable');
+    expect(chips.length).toBe(2);
+    
+    chips.forEach((chip) => {
+      expect(chip.getAttribute('part')).toBe('chip');
+    });
+  });
+
+  it('should apply input--borderless class when borderless prop is true', async () => {
+    const page = await newSpecPage({
+      components: [InputChips],
+      html: '<bds-input-chips borderless></bds-input-chips>',
+    });
+
+    const inputElement = page.root.shadowRoot.querySelector('.input');
+    expect(inputElement).toHaveClass('input--borderless');
+  });
+
+  it('should not apply input--borderless class when borderless prop is false', async () => {
+    const page = await newSpecPage({
+      components: [InputChips],
+      html: '<bds-input-chips></bds-input-chips>',
+    });
+
+    const inputElement = page.root.shadowRoot.querySelector('.input');
+    expect(inputElement).not.toHaveClass('input--borderless');
+  });
 });

--- a/src/components/input-chips/test/input-chips.spec.ts
+++ b/src/components/input-chips/test/input-chips.spec.ts
@@ -619,8 +619,8 @@ describe('bds-input-chips', () => {
     expect(component.internalChips).toEqual(['chip1', 'chip2']);
   });
 
-  // New feature tests for part attribute and borderless prop
-  it('should render chips with part="chip" attribute for external styling', async () => {
+  // New feature tests for part forwarding and borderless prop
+  it('should render chips with exportparts="chip" for external styling', async () => {
     const page = await newSpecPage({
       components: [InputChips],
       html: '<bds-input-chips chips=\'["tag1", "tag2"]\'></bds-input-chips>',
@@ -632,7 +632,7 @@ describe('bds-input-chips', () => {
     expect(chips.length).toBe(2);
     
     chips.forEach((chip) => {
-      expect(chip.getAttribute('part')).toBe('chip');
+      expect(chip.getAttribute('exportparts')).toBe('chip');
     });
   });
 


### PR DESCRIPTION
## Description

Allows consumers to style the visual chip container rendered by `bds-input-chips` while preserving Shadow DOM encapsulation. The PR also adds an opt-in borderless input mode and documented CSS custom properties for chip text, icons, and outline borders.

## Changes

- Exposes the visual `.chip_clickable` container as the `chip` shadow part in `bds-chip-clickable`.
- Re-exports the `chip` part through `bds-input-chips`, including chips rendered inside `bds-tooltip`.
- Adds the `borderless` property to remove the input border while preserving the focus ring.
- Adds `--bds-chip-text-color`, `--bds-chip-icon-color`, and `--bds-chip-border` styling hooks.
- Updates Storybook examples, generated documentation, and unit/E2E coverage.

## Usage

```css
bds-input-chips::part(chip) {
  background-color: #1976d2;
  border-radius: 16px;
}

bds-input-chips {
  --bds-chip-text-color: #ffffff;
  --bds-chip-icon-color: #ffffff;
  --bds-chip-border: 1px solid #1976d2;
}
```

## Validation

- Component build and Storybook build pass.
- Lint passes.
- Input chips unit tests pass.
- Input chips E2E tests pass, including direct and tooltip part forwarding, external styling, and borderless focus behavior.

## Related Issues

Fixes styling of chips within the A2UI Campaign Budget component (Brain MFE).