### PR TITLE
fix(loading-page): use white Blip ballon from tokens

### DIFF
--- a/src/components/loading-page/loading-page.scss
+++ b/src/components/loading-page/loading-page.scss
@@ -23,8 +23,8 @@
 
 .page_loading {
   animation: growUp 0.8s ease-in-out infinite;
-  width: 116px;
-  height: 128px;
+  width: 90px;
+  height: 90px;
   color: $color-surface-1;
 }
 

--- a/src/components/loading-page/loading-page.tsx
+++ b/src/components/loading-page/loading-page.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, Prop, State, h } from '@stencil/core';
-import messageBallon from '../../assets/svg/message-ballon.svg';
+import blipBallonWhite from 'blip-tokens/build/json/illustrations/brand/blip-ballon-white.json';
 
 @Component({
   tag: 'bds-loading-page',
@@ -30,9 +30,9 @@ export class BdsLoading {
   };
 
   setSvgContent = () => {
-    const innerHTML = messageBallon;
+    const innerHTML = blipBallonWhite['asset-brand-blip-ballon-white-svg'];
 
-    const svg = atob(innerHTML.replace('data:image/svg+xml;base64,', ''));
+    const svg = atob(innerHTML);
     this.svgContent = this.formatSvg(svg);
   };
 

--- a/src/components/loading-page/test/loading-page.spec.ts
+++ b/src/components/loading-page/test/loading-page.spec.ts
@@ -75,6 +75,11 @@ describe('bds-loading-page', () => {
       expect(pageLoading.innerHTML).toContain('svg');
     });
 
+    it('should render the white Blip ballon logo', async () => {
+      const pageLoading = page.root.shadowRoot.querySelector('.page_loading');
+      expect(pageLoading.innerHTML).toContain('fill="white"');
+    });
+
     it('should call setSvgContent on componentWillLoad', async () => {
       const spy = jest.spyOn(component, 'setSvgContent');
       component.componentWillLoad();


### PR DESCRIPTION
## Summary
- Replace the loading page message ballon asset with the official `blip-ballon-white` illustration from `blip-tokens`.
- Keep the existing SVG formatting and loading animation behavior.
- Add unit coverage asserting the white logo is rendered.

## Motivation
The loading page should use the current Blip ballon white logo maintained by the design token package instead of a duplicated local asset.

## Validation
- `npm run test:unit -- src/components/loading-page/test/loading-page.spec.ts`
- Commit hook: ESLint and full unit test suite
- `npm run build`

The loading-page E2E test was also attempted, but Chromium could not start in the local environment (`spawn ... -86`).